### PR TITLE
feat: support config.local.yaml for machine-specific overrides

### DIFF
--- a/.overstory/.gitignore
+++ b/.overstory/.gitignore
@@ -1,4 +1,5 @@
 # Runtime state (auto-generated, do not edit)
+config.local.yaml
 worktrees/
 logs/
 mail.db


### PR DESCRIPTION
Hey its me again :)

since the default 25 agents is to much for my hardware, I wanted to change it. But chaning the config directly leaves my workdir permanently dirty. I've implemented a small config override feature and updated the `README.md` to mention how to override configs.

## Summary

  - Support for .overstory/config.local.yaml that deep-merges on top of config.yaml
  - Allows machine-specific overrides (e.g., maxConcurrent on weaker hardware) without dirtying the worktree
  - Gitignored so local overrides never conflict with upstream changes
  - Works even when config.yaml doesn't exist (merges on top of defaults)
  - Values go through the same validation pipeline

  Merge order: defaults <- config.yaml <- config.local.yaml

 ## Changes

  - src/config.ts — mergeLocalConfig() helper called from loadConfig() in both code paths
  - src/config.test.ts — 4 new tests: override, no-config-yaml fallback, validation, deep merge
  - .overstory/.gitignore — Ignore config.local.yaml

 ## Test plan

  - bun test — 1813 pass, 0 fail
  - bun run lint — clean
  - bun run typecheck — clean
