### PR TITLE
fix: detect bd CGO/Dolt backend failure in doctor check

### DIFF
--- a/src/doctor/dependencies.test.ts
+++ b/src/doctor/dependencies.test.ts
@@ -63,6 +63,18 @@ describe("checkDependencies", () => {
 		expect(toolNames).toContain("mulch availability");
 	});
 
+	test("includes bd CGO support check when bd is available", async () => {
+		const checks = await checkDependencies(mockConfig, "/tmp/.overstory");
+
+		const bdCheck = checks.find((c) => c.name === "bd availability");
+		if (bdCheck?.status === "pass") {
+			const cgoCheck = checks.find((c) => c.name === "bd CGO support");
+			expect(cgoCheck).toBeDefined();
+			expect(cgoCheck?.category).toBe("dependencies");
+			expect(["pass", "warn", "fail"]).toContain(cgoCheck?.status ?? "");
+		}
+	});
+
 	test("all checks have required DoctorCheck fields", async () => {
 		const checks = await checkDependencies(mockConfig, "/tmp/.overstory");
 

--- a/src/doctor/dependencies.ts
+++ b/src/doctor/dependencies.ts
@@ -2,7 +2,8 @@ import type { DoctorCheck, DoctorCheckFn } from "./types.ts";
 
 /**
  * External dependency checks.
- * Validates that required CLI tools (git, bun, tmux, bd, mulch) are available.
+ * Validates that required CLI tools (git, bun, tmux, bd, mulch) are available
+ * and that bd has functional CGO support for its Dolt database backend.
  */
 export const checkDependencies: DoctorCheckFn = async (
 	_config,
@@ -23,8 +24,88 @@ export const checkDependencies: DoctorCheckFn = async (
 		checks.push(check);
 	}
 
+	// If bd is available, probe for CGO/Dolt backend functionality
+	const bdCheck = checks.find((c) => c.name === "bd availability");
+	if (bdCheck?.status === "pass") {
+		const cgoCheck = await checkBdCgoSupport();
+		checks.push(cgoCheck);
+	}
+
 	return checks;
 };
+
+/**
+ * Probe whether bd's Dolt database backend is functional.
+ * The npm-distributed bd binary may be built without CGO, which causes
+ * `bd init` and all database operations to fail even though `bd --version` succeeds.
+ * We detect this by running `bd status` in a temp directory and checking for
+ * the characteristic "without CGO support" error message.
+ */
+async function checkBdCgoSupport(): Promise<DoctorCheck> {
+	const { mkdtemp, rm } = await import("node:fs/promises");
+	const { join } = await import("node:path");
+	const { tmpdir } = await import("node:os");
+
+	let tempDir: string | undefined;
+	try {
+		tempDir = await mkdtemp(join(tmpdir(), "overstory-bd-cgo-"));
+		const proc = Bun.spawn(["bd", "status"], {
+			cwd: tempDir,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+
+		const exitCode = await proc.exited;
+		const stderr = await new Response(proc.stderr).text();
+
+		if (stderr.includes("without CGO support")) {
+			return {
+				name: "bd CGO support",
+				category: "dependencies",
+				status: "fail",
+				message: "bd binary was built without CGO — Dolt database operations will fail",
+				details: [
+					"The installed bd binary lacks CGO support required by its Dolt backend.",
+					"Workaround: rebuild bd from source with CGO_ENABLED=1 and ICU headers.",
+					"See: https://github.com/jayminwest/overstory/issues/10",
+				],
+				fixable: true,
+			};
+		}
+
+		// Any other exit code is fine — bd status may fail for other reasons
+		// (no .beads/ dir, etc.) but those aren't CGO issues
+		if (exitCode === 0 || !stderr.includes("CGO")) {
+			return {
+				name: "bd CGO support",
+				category: "dependencies",
+				status: "pass",
+				message: "bd has functional database backend",
+				details: ["Dolt backend operational"],
+			};
+		}
+
+		return {
+			name: "bd CGO support",
+			category: "dependencies",
+			status: "warn",
+			message: `bd status returned unexpected error (exit code ${exitCode})`,
+			details: [stderr.trim().split("\n")[0] || "unknown error"],
+		};
+	} catch (error) {
+		return {
+			name: "bd CGO support",
+			category: "dependencies",
+			status: "warn",
+			message: "Could not verify bd CGO support",
+			details: [error instanceof Error ? error.message : String(error)],
+		};
+	} finally {
+		if (tempDir) {
+			await rm(tempDir, { recursive: true }).catch(() => {});
+		}
+	}
+}
 
 /**
  * Check if a CLI tool is available by attempting to run it with a version flag.


### PR DESCRIPTION
## Summary

- Add a deeper `bd` health probe to `overstory doctor --category dependencies` that detects when the installed `bd` binary lacks CGO support
- The existing check only runs `bd --version`, which succeeds even when the Dolt database backend is non-functional
- New check runs `bd status` in a temp directory to catch the "without CGO support" error, with actionable remediation details

## Context

The npm-distributed `bd` v0.52.0 binary (`@beads/bd@0.52.0`) ships without CGO, which breaks all Dolt database operations (`bd init`, `bd status`, `bd close`, etc.). This silently blocks the overstory sling workflow since agents rely on `bd` for task lifecycle management.

Closes #10

## Test plan

- [x] All 1853 existing tests pass
- [x] New test verifies CGO check is included when `bd` is available
- [x] Biome lint clean
- [x] TypeScript typecheck clean