### PR TITLE
feat(web): Add browser-based dashboard server

### DIFF
--- a/dashboard/dashboard.css
+++ b/dashboard/dashboard.css
@@ -1,0 +1,1159 @@
+/* ── Catppuccin Mocha ── */
+:root {
+	--rosewater: #f5e0dc;
+	--flamingo: #f2cdcd;
+	--pink: #f5c2e7;
+	--mauve: #cba6f7;
+	--red: #f38ba8;
+	--maroon: #eba0ac;
+	--peach: #fab387;
+	--yellow: #f9e2af;
+	--green: #a6e3a1;
+	--teal: #94e2d5;
+	--sky: #89dcfe;
+	--sapphire: #74c7ec;
+	--blue: #89b4fa;
+	--lavender: #b4befe;
+	--text: #cdd6f4;
+	--subtext1: #bac2de;
+	--subtext0: #a6adc8;
+	--overlay2: #9399b2;
+	--overlay1: #7f849c;
+	--overlay0: #6c7086;
+	--surface2: #585b70;
+	--surface1: #45475a;
+	--surface0: #313244;
+	--base: #1e1e2e;
+	--mantle: #181825;
+	--crust: #11111b;
+}
+
+/* ── Reset & Base ── */
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+	margin: 0;
+	padding: 0;
+}
+html,
+body {
+	height: 100%;
+	overflow: hidden;
+}
+body {
+	font-family: "Exo 2", sans-serif;
+	background: var(--base);
+	color: var(--text);
+	background-image: radial-gradient(var(--surface0) 0.5px, transparent 0.5px);
+	background-size: 24px 24px;
+}
+
+/* ── Scrollbar ── */
+::-webkit-scrollbar {
+	width: 5px;
+	height: 5px;
+}
+::-webkit-scrollbar-track {
+	background: transparent;
+}
+::-webkit-scrollbar-thumb {
+	background: var(--surface1);
+	border-radius: 3px;
+}
+::-webkit-scrollbar-thumb:hover {
+	background: var(--surface2);
+}
+
+/* ── Dashboard Grid ── */
+.dashboard {
+	display: grid;
+	grid-template-columns: 280px 1fr 420px;
+	grid-template-rows: 42px 1fr;
+	grid-template-areas: "topbar topbar topbar" "sidebar center right";
+	height: 100vh;
+	gap: 1px;
+	background: var(--surface0);
+}
+@media (min-width: 2560px) {
+	.dashboard {
+		grid-template-columns: 320px 1fr 520px;
+	}
+}
+
+/* ── Topbar ── */
+.topbar {
+	grid-area: topbar;
+	background: var(--mantle);
+	display: flex;
+	align-items: center;
+	padding: 0 16px;
+	gap: 16px;
+	border-bottom: 1px solid var(--surface0);
+	z-index: 10;
+}
+.topbar-left {
+	display: flex;
+	align-items: baseline;
+	gap: 10px;
+}
+.logo {
+	font-size: 15px;
+	font-weight: 700;
+	letter-spacing: 3px;
+	color: var(--peach);
+}
+.logo-sub {
+	font-size: 11px;
+	color: var(--overlay0);
+	font-weight: 400;
+	letter-spacing: 1px;
+	text-transform: lowercase;
+}
+.topbar-stats {
+	display: flex;
+	gap: 20px;
+	flex: 1;
+	justify-content: center;
+}
+.topbar-stat {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 12px;
+	color: var(--subtext0);
+}
+.topbar-stat .val {
+	font-family: "JetBrains Mono", monospace;
+	font-weight: 600;
+	font-size: 13px;
+	color: var(--text);
+}
+.topbar-right {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+}
+.topbar-time {
+	font-family: "JetBrains Mono", monospace;
+	font-size: 11px;
+	color: var(--overlay1);
+}
+.nav-link {
+	font-size: 11px;
+	color: var(--overlay1);
+	text-decoration: none;
+	padding: 3px 8px;
+	border: 1px solid var(--surface1);
+	border-radius: 4px;
+	transition: all 0.2s;
+}
+.nav-link:hover {
+	color: var(--text);
+	border-color: var(--surface2);
+}
+
+/* Refresh indicator */
+.refresh-indicator {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: var(--green);
+	transition: opacity 0.3s;
+}
+.refresh-indicator.pulsing {
+	animation: pulse 0.6s ease-in-out;
+}
+@keyframes pulse {
+	0%,
+	100% {
+		opacity: 1;
+		transform: scale(1);
+	}
+	50% {
+		opacity: 0.4;
+		transform: scale(1.5);
+	}
+}
+
+/* ── Sidebar ── */
+.sidebar {
+	grid-area: sidebar;
+	background: var(--mantle);
+	overflow-y: auto;
+	padding: 0;
+}
+.sidebar-section-label {
+	font-size: 10px;
+	font-weight: 600;
+	letter-spacing: 2px;
+	color: var(--overlay0);
+	padding: 12px 14px 6px;
+	position: sticky;
+	top: 0;
+	background: var(--mantle);
+	z-index: 2;
+}
+.agent-list {
+	padding: 0 0 12px;
+}
+.agent-node {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 5px 10px 5px 12px;
+	cursor: pointer;
+	font-size: 12px;
+	transition: background 0.15s;
+	border-left: 2px solid transparent;
+}
+.agent-node:hover {
+	background: var(--surface0);
+}
+.agent-node.selected {
+	background: var(--surface0);
+	border-left-color: var(--blue);
+}
+.agent-node.completed {
+	opacity: 0.5;
+}
+.agent-node.completed:hover {
+	opacity: 0.8;
+}
+.tree-prefix {
+	font-family: "JetBrains Mono", monospace;
+	font-size: 11px;
+	color: var(--surface2);
+	white-space: pre;
+	user-select: none;
+	flex-shrink: 0;
+}
+.state-dot {
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	flex-shrink: 0;
+}
+.state-dot.working {
+	background: var(--green);
+	box-shadow: 0 0 6px var(--green);
+}
+.state-dot.booting {
+	background: var(--blue);
+	animation: pulse 1.5s infinite;
+}
+.state-dot.stalled {
+	background: var(--yellow);
+	box-shadow: 0 0 6px var(--yellow);
+}
+.state-dot.completed {
+	background: var(--overlay0);
+}
+.state-dot.zombie {
+	background: var(--red);
+	box-shadow: 0 0 6px var(--red);
+}
+.state-dot.stopped {
+	background: var(--surface2);
+}
+.agent-info {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	min-width: 0;
+	flex: 1;
+}
+.agent-name-text {
+	font-family: "JetBrains Mono", monospace;
+	font-size: 11px;
+	font-weight: 500;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	color: var(--text);
+}
+.agent-cap {
+	font-size: 9px;
+	font-weight: 600;
+	letter-spacing: 0.5px;
+	padding: 1px 5px;
+	border-radius: 3px;
+	flex-shrink: 0;
+	text-transform: uppercase;
+}
+.cap-orchestrator {
+	background: color-mix(in srgb, var(--peach) 20%, transparent);
+	color: var(--peach);
+}
+.cap-lead {
+	background: color-mix(in srgb, var(--mauve) 20%, transparent);
+	color: var(--mauve);
+}
+.cap-scout {
+	background: color-mix(in srgb, var(--teal) 20%, transparent);
+	color: var(--teal);
+}
+.cap-builder {
+	background: color-mix(in srgb, var(--sapphire) 20%, transparent);
+	color: var(--sapphire);
+}
+.cap-reviewer {
+	background: color-mix(in srgb, var(--lavender) 20%, transparent);
+	color: var(--lavender);
+}
+.cap-merger {
+	background: color-mix(in srgb, var(--pink) 20%, transparent);
+	color: var(--pink);
+}
+.cap-supervisor {
+	background: color-mix(in srgb, var(--yellow) 20%, transparent);
+	color: var(--yellow);
+}
+.cap-monitor {
+	background: color-mix(in srgb, var(--sky) 20%, transparent);
+	color: var(--sky);
+}
+.agent-dur {
+	font-family: "JetBrains Mono", monospace;
+	font-size: 10px;
+	color: var(--overlay1);
+	flex-shrink: 0;
+	margin-left: auto;
+}
+
+/* ── Center Panel ── */
+.center {
+	grid-area: center;
+	background: var(--base);
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+.center-header {
+	background: var(--mantle);
+	border-bottom: 1px solid var(--surface0);
+	padding: 0 16px;
+	flex-shrink: 0;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	min-height: 40px;
+}
+.agent-identity {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+.agent-id-name {
+	font-family: "JetBrains Mono", monospace;
+	font-size: 14px;
+	font-weight: 600;
+}
+.agent-id-meta {
+	font-size: 11px;
+	color: var(--subtext0);
+	display: flex;
+	gap: 12px;
+}
+.agent-id-meta span {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+}
+.empty-hint {
+	color: var(--overlay0);
+	font-size: 12px;
+}
+.center-tabs {
+	display: flex;
+	gap: 2px;
+}
+.center-content {
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+	padding: 16px;
+}
+.center-content:has(.xterm-wrap) {
+	display: flex;
+	flex-direction: column;
+	padding: 8px;
+	overflow: hidden;
+}
+
+/* ── Tabs ── */
+.tab {
+	background: transparent;
+	border: none;
+	color: var(--overlay1);
+	font-family: "Exo 2", sans-serif;
+	font-size: 11px;
+	font-weight: 500;
+	padding: 6px 12px;
+	cursor: pointer;
+	border-radius: 4px;
+	transition: all 0.15s;
+	letter-spacing: 0.5px;
+}
+.tab:hover {
+	color: var(--text);
+	background: var(--surface0);
+}
+.tab.active {
+	color: var(--text);
+	background: var(--surface0);
+}
+
+/* ── Right Panel ── */
+.right-panel {
+	grid-area: right;
+	background: var(--mantle);
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+.right-tabs {
+	display: flex;
+	gap: 2px;
+	padding: 6px 10px;
+	border-bottom: 1px solid var(--surface0);
+	flex-shrink: 0;
+}
+.right-content {
+	flex: 1;
+	overflow-y: auto;
+	padding: 8px;
+}
+
+/* ── Empty States ── */
+.empty-state {
+	color: var(--overlay0);
+	font-size: 12px;
+	padding: 20px;
+	text-align: center;
+}
+.center-empty {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+	gap: 12px;
+}
+.empty-icon {
+	font-size: 32px;
+	color: var(--surface2);
+}
+
+/* ── Mail Message ── */
+.mail-item {
+	background: var(--surface0);
+	border-radius: 6px;
+	padding: 10px 12px;
+	margin-bottom: 6px;
+	cursor: pointer;
+	border-left: 3px solid var(--surface1);
+	transition: all 0.15s;
+}
+.mail-item:hover {
+	background: var(--surface1);
+}
+.mail-item.unread {
+	border-left-color: var(--blue);
+}
+.mail-item.priority-high {
+	border-left-color: var(--peach);
+}
+.mail-item.priority-urgent {
+	border-left-color: var(--red);
+}
+.mail-header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 4px;
+}
+.mail-route {
+	font-family: "JetBrains Mono", monospace;
+	font-size: 10px;
+	color: var(--subtext0);
+}
+.mail-route .from {
+	color: var(--teal);
+}
+.mail-route .to {
+	color: var(--mauve);
+}
+.mail-type {
+	font-size: 8px;
+	font-weight: 600;
+	letter-spacing: 0.5px;
+	padding: 1px 5px;
+	border-radius: 3px;
+	text-transform: uppercase;
+}
+.type-status {
+	background: color-mix(in srgb, var(--blue) 20%, transparent);
+	color: var(--blue);
+}
+.type-merge_ready {
+	background: color-mix(in srgb, var(--green) 20%, transparent);
+	color: var(--green);
+}
+.type-error {
+	background: color-mix(in srgb, var(--red) 20%, transparent);
+	color: var(--red);
+}
+.type-escalation {
+	background: color-mix(in srgb, var(--yellow) 20%, transparent);
+	color: var(--yellow);
+}
+.type-dispatch {
+	background: color-mix(in srgb, var(--peach) 20%, transparent);
+	color: var(--peach);
+}
+.type-worker_done {
+	background: color-mix(in srgb, var(--green) 20%, transparent);
+	color: var(--green);
+}
+.type-merged {
+	background: color-mix(in srgb, var(--teal) 20%, transparent);
+	color: var(--teal);
+}
+.type-question {
+	background: color-mix(in srgb, var(--mauve) 20%, transparent);
+	color: var(--mauve);
+}
+.type-result {
+	background: color-mix(in srgb, var(--lavender) 20%, transparent);
+	color: var(--lavender);
+}
+.mail-time {
+	font-family: "JetBrains Mono", monospace;
+	font-size: 9px;
+	color: var(--overlay0);
+	margin-left: auto;
+	flex-shrink: 0;
+}
+.mail-subject {
+	font-size: 12px;
+	font-weight: 500;
+	color: var(--text);
+	margin-bottom: 2px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.mail-body {
+	font-family: "JetBrains Mono", monospace;
+	font-size: 10px;
+	line-height: 1.5;
+	color: var(--subtext0);
+	white-space: pre-wrap;
+	word-break: break-word;
+	max-height: 0;
+	overflow: hidden;
+	transition: max-height 0.3s ease;
+}
+.mail-item.expanded .mail-body {
+	max-height: 2000px;
+}
+.mail-body-preview {
+	font-size: 10px;
+	color: var(--overlay1);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+/* ── Terminal View ── */
+.terminal-wrap {
+	background: var(--crust);
+	border-radius: 8px;
+	overflow: hidden;
+	border: 1px solid var(--surface0);
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+}
+.terminal-titlebar {
+	background: var(--surface0);
+	padding: 6px 12px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex-shrink: 0;
+}
+.terminal-dots {
+	display: flex;
+	gap: 5px;
+}
+.terminal-dots span {
+	width: 9px;
+	height: 9px;
+	border-radius: 50%;
+}
+.terminal-dots span:nth-child(1) {
+	background: var(--red);
+}
+.terminal-dots span:nth-child(2) {
+	background: var(--yellow);
+}
+.terminal-dots span:nth-child(3) {
+	background: var(--green);
+}
+.terminal-session {
+	font-family: "JetBrains Mono", monospace;
+	font-size: 10px;
+	color: var(--overlay1);
+}
+.terminal-body {
+	flex: 1;
+	overflow-y: auto;
+	padding: 10px 14px;
+}
+.terminal-body pre {
+	font-family: "JetBrains Mono NF", "JetBrains Mono", monospace;
+	font-size: 11px;
+	line-height: 1.45;
+	color: var(--text);
+	white-space: pre-wrap;
+	word-break: break-all;
+	margin: 0;
+}
+
+/* ── xterm.js Terminal ── */
+.xterm-wrap {
+	flex: 1;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+	background: var(--crust);
+	border-radius: 8px;
+	overflow: hidden;
+	border: 1px solid var(--surface0);
+}
+.xterm-titlebar {
+	background: var(--surface0);
+	padding: 6px 12px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex-shrink: 0;
+}
+#xterm-container {
+	flex: 1;
+	overflow: hidden;
+}
+#xterm-container .xterm {
+	height: 100%;
+}
+
+/* ── Start Orchestrator Button ── */
+.start-orchestrator-btn {
+	display: block;
+	width: calc(100% - 24px);
+	margin: 8px 12px;
+	padding: 8px 12px;
+	background: color-mix(in srgb, var(--green) 15%, var(--surface0));
+	border: 1px solid var(--green);
+	border-radius: 6px;
+	color: var(--green);
+	font-family: "Exo 2", sans-serif;
+	font-size: 12px;
+	font-weight: 600;
+	cursor: pointer;
+	transition: all 0.2s;
+	letter-spacing: 0.5px;
+}
+.start-orchestrator-btn:hover {
+	background: color-mix(in srgb, var(--green) 25%, var(--surface0));
+}
+
+/* ── Overview Cards ── */
+.overview-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+	gap: 12px;
+}
+@media (min-width: 2560px) {
+	.overview-grid {
+		grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+	}
+}
+.ov-card {
+	background: var(--surface0);
+	border-radius: 6px;
+	padding: 14px;
+}
+.ov-card-title {
+	font-size: 10px;
+	font-weight: 600;
+	letter-spacing: 1.5px;
+	color: var(--overlay0);
+	margin-bottom: 10px;
+	text-transform: uppercase;
+}
+.ov-row {
+	display: flex;
+	justify-content: space-between;
+	padding: 3px 0;
+	font-size: 12px;
+}
+.ov-row .label {
+	color: var(--subtext0);
+}
+.ov-row .value {
+	font-family: "JetBrains Mono", monospace;
+	font-size: 11px;
+	color: var(--text);
+}
+
+/* ── Trace Timeline ── */
+.trace-item {
+	display: flex;
+	align-items: flex-start;
+	gap: 10px;
+	padding: 6px 0;
+	border-bottom: 1px solid color-mix(in srgb, var(--surface0) 50%, transparent);
+	font-size: 11px;
+}
+.trace-time {
+	font-family: "JetBrains Mono", monospace;
+	font-size: 10px;
+	color: var(--overlay1);
+	flex-shrink: 0;
+	width: 70px;
+}
+.trace-type {
+	font-size: 9px;
+	font-weight: 600;
+	padding: 1px 6px;
+	border-radius: 3px;
+	flex-shrink: 0;
+	text-transform: uppercase;
+	letter-spacing: 0.3px;
+}
+.trace-tool {
+	font-family: "JetBrains Mono", monospace;
+	font-size: 11px;
+	color: var(--text);
+	flex-shrink: 0;
+}
+.trace-detail {
+	color: var(--subtext0);
+	font-size: 10px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	flex: 1;
+	min-width: 0;
+}
+.trace-dur {
+	font-family: "JetBrains Mono", monospace;
+	font-size: 10px;
+	color: var(--overlay0);
+	flex-shrink: 0;
+}
+
+/* ── Merge Queue ── */
+.merge-item {
+	background: var(--surface0);
+	border-radius: 6px;
+	padding: 10px 12px;
+	margin-bottom: 6px;
+}
+.merge-branch {
+	font-family: "JetBrains Mono", monospace;
+	font-size: 11px;
+	color: var(--text);
+	margin-bottom: 4px;
+}
+.merge-meta {
+	display: flex;
+	gap: 10px;
+	font-size: 10px;
+	color: var(--subtext0);
+}
+.merge-status {
+	font-size: 9px;
+	font-weight: 600;
+	padding: 1px 6px;
+	border-radius: 3px;
+	text-transform: uppercase;
+}
+.merge-pending {
+	background: color-mix(in srgb, var(--yellow) 20%, transparent);
+	color: var(--yellow);
+}
+.merge-merging {
+	background: color-mix(in srgb, var(--blue) 20%, transparent);
+	color: var(--blue);
+}
+.merge-merged {
+	background: color-mix(in srgb, var(--green) 20%, transparent);
+	color: var(--green);
+}
+.merge-conflict {
+	background: color-mix(in srgb, var(--red) 20%, transparent);
+	color: var(--red);
+}
+.merge-failed {
+	background: color-mix(in srgb, var(--red) 20%, transparent);
+	color: var(--red);
+}
+
+/* ── Events Feed ── */
+.event-item {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 5px 8px;
+	font-size: 11px;
+	border-bottom: 1px solid color-mix(in srgb, var(--surface0) 40%, transparent);
+}
+.event-time {
+	font-family: "JetBrains Mono", monospace;
+	font-size: 9px;
+	color: var(--overlay0);
+	flex-shrink: 0;
+	width: 52px;
+}
+.event-level {
+	font-size: 8px;
+	font-weight: 600;
+	padding: 1px 4px;
+	border-radius: 2px;
+	text-transform: uppercase;
+	flex-shrink: 0;
+}
+.level-info {
+	background: color-mix(in srgb, var(--blue) 15%, transparent);
+	color: var(--blue);
+}
+.level-warn {
+	background: color-mix(in srgb, var(--yellow) 15%, transparent);
+	color: var(--yellow);
+}
+.level-error {
+	background: color-mix(in srgb, var(--red) 15%, transparent);
+	color: var(--red);
+}
+.level-debug {
+	background: color-mix(in srgb, var(--overlay0) 15%, transparent);
+	color: var(--overlay0);
+}
+.event-agent {
+	font-family: "JetBrains Mono", monospace;
+	font-size: 10px;
+	color: var(--subtext0);
+	flex-shrink: 0;
+	max-width: 100px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.event-detail {
+	font-size: 10px;
+	color: var(--overlay1);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	flex: 1;
+}
+
+/* ── Metrics ── */
+.metrics-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+	gap: 8px;
+	margin-bottom: 16px;
+}
+.metric-card {
+	background: var(--surface0);
+	border-radius: 6px;
+	padding: 12px;
+	text-align: center;
+}
+.metric-val {
+	font-family: "JetBrains Mono", monospace;
+	font-size: 22px;
+	font-weight: 600;
+	color: var(--text);
+}
+.metric-label {
+	font-size: 10px;
+	color: var(--overlay0);
+	letter-spacing: 0.5px;
+	margin-top: 4px;
+}
+.metrics-table {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: 11px;
+}
+.metrics-table th {
+	text-align: left;
+	font-size: 10px;
+	font-weight: 600;
+	color: var(--overlay0);
+	letter-spacing: 0.5px;
+	padding: 6px 8px;
+	border-bottom: 1px solid var(--surface0);
+	text-transform: uppercase;
+}
+.metrics-table td {
+	padding: 5px 8px;
+	border-bottom: 1px solid color-mix(in srgb, var(--surface0) 40%, transparent);
+	font-family: "JetBrains Mono", monospace;
+	font-size: 10px;
+}
+.metrics-table tr:hover {
+	background: var(--surface0);
+}
+
+/* ── Utility ── */
+.state-badge {
+	font-size: 9px;
+	font-weight: 600;
+	padding: 1px 6px;
+	border-radius: 3px;
+	text-transform: uppercase;
+}
+.badge-working {
+	background: color-mix(in srgb, var(--green) 20%, transparent);
+	color: var(--green);
+}
+.badge-booting {
+	background: color-mix(in srgb, var(--blue) 20%, transparent);
+	color: var(--blue);
+}
+.badge-stalled {
+	background: color-mix(in srgb, var(--yellow) 20%, transparent);
+	color: var(--yellow);
+}
+.badge-completed {
+	background: color-mix(in srgb, var(--overlay0) 20%, transparent);
+	color: var(--overlay0);
+}
+.badge-zombie {
+	background: color-mix(in srgb, var(--red) 20%, transparent);
+	color: var(--red);
+}
+.filter-bar {
+	display: flex;
+	gap: 4px;
+	margin-bottom: 8px;
+	flex-wrap: wrap;
+}
+.filter-btn {
+	font-family: "Exo 2", sans-serif;
+	font-size: 10px;
+	padding: 3px 8px;
+	border: 1px solid var(--surface1);
+	background: transparent;
+	color: var(--overlay1);
+	border-radius: 4px;
+	cursor: pointer;
+	transition: all 0.15s;
+}
+.filter-btn:hover {
+	border-color: var(--surface2);
+	color: var(--text);
+}
+.filter-btn.active {
+	background: var(--surface0);
+	color: var(--text);
+	border-color: var(--blue);
+}
+
+/* ── Usage Panel ── */
+.usage-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 12px;
+}
+.usage-window-label {
+	font-size: 10px;
+	color: var(--overlay0);
+	letter-spacing: 0.5px;
+}
+.usage-window-val {
+	font-family: "JetBrains Mono", monospace;
+	font-size: 10px;
+	color: var(--subtext0);
+}
+
+/* Gauge bar */
+.usage-gauge-wrap {
+	margin-bottom: 16px;
+}
+.usage-gauge-label {
+	display: flex;
+	justify-content: space-between;
+	font-size: 10px;
+	margin-bottom: 4px;
+}
+.usage-gauge-label .lbl {
+	color: var(--subtext0);
+}
+.usage-gauge-label .pct {
+	font-family: "JetBrains Mono", monospace;
+	font-weight: 600;
+}
+.usage-gauge {
+	height: 8px;
+	background: var(--surface0);
+	border-radius: 4px;
+	overflow: hidden;
+	position: relative;
+}
+.usage-gauge-fill {
+	height: 100%;
+	border-radius: 4px;
+	transition:
+		width 0.6s ease,
+		background 0.3s;
+	min-width: 2px;
+}
+.gauge-low {
+	background: var(--green);
+}
+.gauge-mid {
+	background: var(--yellow);
+}
+.gauge-high {
+	background: var(--peach);
+}
+.gauge-crit {
+	background: var(--red);
+}
+
+/* Model breakdown cards */
+.usage-models {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 6px;
+	margin-bottom: 16px;
+}
+.usage-model-row {
+	background: var(--surface0);
+	border-radius: 6px;
+	padding: 10px 12px;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+.usage-model-name {
+	font-family: "JetBrains Mono", monospace;
+	font-size: 11px;
+	color: var(--text);
+	min-width: 120px;
+	flex-shrink: 0;
+}
+.usage-model-bar-wrap {
+	flex: 1;
+	height: 6px;
+	background: var(--surface1);
+	border-radius: 3px;
+	overflow: hidden;
+}
+.usage-model-bar {
+	height: 100%;
+	border-radius: 3px;
+	transition: width 0.4s ease;
+}
+.model-opus {
+	background: var(--peach);
+}
+.model-sonnet {
+	background: var(--blue);
+}
+.model-haiku {
+	background: var(--teal);
+}
+.usage-model-stats {
+	font-family: "JetBrains Mono", monospace;
+	font-size: 10px;
+	color: var(--subtext0);
+	display: flex;
+	gap: 10px;
+	flex-shrink: 0;
+}
+.usage-model-stats .cost {
+	color: var(--peach);
+}
+
+/* Sparkline */
+.usage-sparkline-wrap {
+	margin-bottom: 16px;
+}
+.usage-sparkline-title {
+	font-size: 10px;
+	font-weight: 600;
+	letter-spacing: 1.5px;
+	color: var(--overlay0);
+	margin-bottom: 6px;
+	text-transform: uppercase;
+}
+.usage-sparkline {
+	height: 60px;
+	display: flex;
+	align-items: flex-end;
+	gap: 1px;
+	background: var(--surface0);
+	border-radius: 6px;
+	padding: 8px 4px 4px;
+}
+.spark-bar {
+	flex: 1;
+	background: var(--blue);
+	border-radius: 2px 2px 0 0;
+	min-height: 1px;
+	transition: height 0.3s ease;
+	opacity: 0.7;
+}
+.spark-bar:hover {
+	opacity: 1;
+}
+.spark-bar.current {
+	background: var(--green);
+	opacity: 1;
+}
+.sparkline-labels {
+	display: flex;
+	justify-content: space-between;
+	font-family: "JetBrains Mono", monospace;
+	font-size: 8px;
+	color: var(--overlay0);
+	margin-top: 2px;
+	padding: 0 4px;
+}
+
+/* Topbar usage mini-gauge */
+.topbar-usage {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+.topbar-usage-label {
+	font-size: 10px;
+	color: var(--overlay1);
+}
+.topbar-usage-bar {
+	width: 60px;
+	height: 4px;
+	background: var(--surface1);
+	border-radius: 2px;
+	overflow: hidden;
+}
+.topbar-usage-fill {
+	height: 100%;
+	border-radius: 2px;
+	transition: width 0.6s ease;
+}
+.topbar-usage-pct {
+	font-family: "JetBrains Mono", monospace;
+	font-size: 10px;
+	font-weight: 600;
+}

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -1,0 +1,1044 @@
+(() => {
+	// ── State ──
+	// Detect browser's default hour cycle: h23/h24 → 24h, h11/h12 → 12h
+	const _browserUses24h = (() => {
+		try {
+			const hc = new Intl.DateTimeFormat(undefined, { hour: "numeric" }).resolvedOptions()
+				.hourCycle;
+			return hc === "h23" || hc === "h24";
+		} catch {
+			return true;
+		}
+	})();
+
+	const S = {
+		sessions: [],
+		selectedAgent: null,
+		centerTab: "overview",
+		rightTab: "inbox",
+		mail: [],
+		mergeQueue: [],
+		events: [],
+		metrics: [],
+		inspect: null,
+		trace: [],
+		use24h: _browserUses24h,
+		agentMail: [],
+		tmux: "",
+		status: null,
+		lastMailRefresh: 0,
+		lastMetricsRefresh: 0,
+		usage: null,
+		lastUsageRefresh: 0,
+	};
+
+	const $ = (id) => document.getElementById(id);
+	const REFRESH = 3000;
+	const MAIL_REFRESH = 8000;
+	const METRICS_REFRESH = 15000;
+
+	// ── Utils ──
+
+	function fmtTime(date) {
+		if (!date) date = new Date();
+		return date.toLocaleTimeString(undefined, { hour12: !S.use24h });
+	}
+
+	function esc(s) {
+		if (!s) return "";
+		const d = document.createElement("div");
+		d.textContent = String(s);
+		return d.innerHTML;
+	}
+
+	function timeAgo(iso) {
+		if (!iso) return "";
+		const diff = Date.now() - new Date(iso).getTime();
+		if (diff < 0) return "just now";
+		const s = Math.floor(diff / 1000);
+		if (s < 60) return `${s}s ago`;
+		const m = Math.floor(s / 60);
+		if (m < 60) return `${m}m ago`;
+		const h = Math.floor(m / 60);
+		if (h < 24) return `${h}h ago`;
+		return `${Math.floor(h / 24)}d ago`;
+	}
+
+	function dur(ms) {
+		if (!ms && ms !== 0) return "";
+		const s = Math.floor(ms / 1000);
+		if (s < 60) return `${s}s`;
+		const m = Math.floor(s / 60);
+		if (m < 60) return `${m}m ${s % 60}s`;
+		const h = Math.floor(m / 60);
+		return `${h}h ${m % 60}m`;
+	}
+
+	function durFromDates(start, end) {
+		if (!start) return "";
+		const ms = (end ? new Date(end) : new Date()) - new Date(start);
+		return dur(ms);
+	}
+
+	// ── API ──
+
+	async function api(path) {
+		try {
+			const r = await fetch(path);
+			if (!r.ok) return { error: `HTTP ${r.status}` };
+			const ct = r.headers.get("content-type") || "";
+			if (ct.includes("text/plain")) return await r.text();
+			return await r.json();
+		} catch (e) {
+			return { error: e.message };
+		}
+	}
+
+	// ── Agent Tree ──
+
+	function buildTree(sessions) {
+		const byName = {};
+		const arr = Array.isArray(sessions) ? sessions : [];
+		arr.forEach((s) => {
+			byName[s.agent_name] = { ...s, children: [] };
+		});
+		const roots = [];
+		arr.forEach((s) => {
+			if (s.parent_agent && byName[s.parent_agent]) {
+				byName[s.parent_agent].children.push(byName[s.agent_name]);
+			} else {
+				roots.push(byName[s.agent_name]);
+			}
+		});
+		return roots;
+	}
+
+	function flattenTree(nodes, prefix, _parentIsLast) {
+		const items = [];
+		nodes.forEach((node, i) => {
+			const isLast = i === nodes.length - 1;
+			const connector = prefix === "" ? "" : isLast ? "\u2514\u2500 " : "\u251C\u2500 ";
+			items.push({ node, prefix: prefix + connector });
+			if (node.children.length) {
+				const childPrefix = prefix === "" ? "" : prefix + (isLast ? "   " : "\u2502  ");
+				items.push(...flattenTree(node.children, childPrefix));
+			}
+		});
+		return items;
+	}
+
+	// ── Sidebar ──
+
+	window._startOrchestrator = async () => {
+		const btn = document.querySelector(".start-orchestrator-btn");
+		if (btn) {
+			btn.textContent = "Starting...";
+			btn.disabled = true;
+		}
+		const result = await api("/dash/api/terminal-start");
+		if (result.error) {
+			if (btn) {
+				btn.textContent = "Retry Start";
+				btn.disabled = false;
+				const errDiv =
+					btn.parentElement.querySelector(".start-error") || document.createElement("div");
+				errDiv.className = "start-error";
+				errDiv.style.cssText =
+					"color:var(--red,#f38ba8);font-size:12px;margin-top:8px;max-width:400px;word-break:break-word";
+				errDiv.textContent = result.error;
+				if (!btn.parentElement.querySelector(".start-error")) btn.parentElement.appendChild(errDiv);
+			}
+			return;
+		}
+		if (btn) btn.textContent = "Started! Loading...";
+		setTimeout(() => refresh(), 2000);
+	};
+
+	function renderSidebar() {
+		const list = $("agent-list");
+		const hasOrchestrator =
+			Array.isArray(S.sessions) &&
+			S.sessions.some(
+				(s) =>
+					s.agent_name === "orchestrator" && ["working", "booting", "stalled"].includes(s.state),
+			);
+		let btnHtml = "";
+		if (!hasOrchestrator) {
+			btnHtml =
+				'<button class="start-orchestrator-btn" onclick="window._startOrchestrator()">Start Orchestrator</button>';
+		}
+		if (!Array.isArray(S.sessions) || S.sessions.length === 0) {
+			list.innerHTML = `${btnHtml}<div class="empty-state">No sessions found</div>`;
+			return;
+		}
+		const tree = buildTree(S.sessions);
+		const flat = flattenTree(tree, "");
+		let html = "";
+		for (const { node, prefix } of flat) {
+			const active = ["working", "booting", "stalled"].includes(node.state);
+			const sel = S.selectedAgent === node.agent_name ? " selected" : "";
+			const cls = active ? "" : " completed";
+			html += `<div class="agent-node${sel}${cls}" onclick="window._selectAgent('${esc(node.agent_name)}')">
+        <span class="tree-prefix">${esc(prefix)}</span>
+        <span class="state-dot ${esc(node.state)}"></span>
+        <span class="agent-info">
+          <span class="agent-name-text">${esc(node.agent_name)}</span>
+          <span class="agent-cap cap-${esc(node.capability)}">${esc(node.capability)}</span>
+        </span>
+        <span class="agent-dur">${durFromDates(node.started_at)}</span>
+      </div>`;
+		}
+		list.innerHTML = btnHtml + html;
+	}
+
+	// ── Stats ──
+
+	function renderStats() {
+		const st = S.status || {};
+		const active = Array.isArray(st.agents) ? st.agents.length : 0;
+		const unread = st.unreadMailCount || 0;
+		const merges = st.mergeQueueCount || 0;
+		const worktrees = Array.isArray(st.worktrees) ? st.worktrees.length : 0;
+		$("topbar-stats").innerHTML = `
+      <div class="topbar-stat"><span class="val">${active}</span> active</div>
+      <div class="topbar-stat"><span class="val">${unread}</span> unread</div>
+      <div class="topbar-stat"><span class="val">${merges}</span> merges</div>
+      <div class="topbar-stat"><span class="val">${worktrees}</span> worktrees</div>
+    `;
+		$("topbar-time").textContent = fmtTime();
+	}
+
+	// ── Center Panel ──
+
+	window._selectAgent = (name) => {
+		cleanupTerminal();
+		S.selectedAgent = name;
+		S.centerTab = "overview";
+		renderSidebar();
+		renderCenterHeader();
+		loadAgentDetail();
+	};
+
+	function renderCenterHeader() {
+		const id = $("agent-identity");
+		if (!S.selectedAgent) {
+			id.innerHTML = '<span class="empty-hint">Select an agent to inspect</span>';
+			return;
+		}
+		const session = S.sessions.find((s) => s.agent_name === S.selectedAgent);
+		if (!session) {
+			id.innerHTML = `<span class="empty-hint">${esc(S.selectedAgent)}</span>`;
+			return;
+		}
+		id.innerHTML = `
+      <span class="state-dot ${esc(session.state)}"></span>
+      <span class="agent-id-name">${esc(session.agent_name)}</span>
+      <span class="agent-cap cap-${esc(session.capability)}">${esc(session.capability)}</span>
+      <span class="agent-id-meta">
+        <span>${esc(session.bead_id || "")}</span>
+        <span>${durFromDates(session.started_at)}</span>
+        <span class="state-badge badge-${esc(session.state)}">${esc(session.state)}</span>
+      </span>
+    `;
+	}
+
+	async function loadAgentDetail() {
+		if (!S.selectedAgent) return;
+		const agent = S.selectedAgent;
+		// Load inspect + agent mail in parallel
+		const [inspect, mail] = await Promise.all([
+			api(`/dash/api/inspect/${agent}`),
+			api(`/dash/api/mail?agent=${agent}&limit=50`),
+		]);
+		if (S.selectedAgent !== agent) return; // agent changed during load
+		S.inspect = inspect;
+		S.agentMail = Array.isArray(mail) ? mail : [];
+		renderCenter();
+	}
+
+	function renderCenter() {
+		// Update tab active states
+		$("center-tabs")
+			.querySelectorAll(".tab")
+			.forEach((t) => {
+				t.classList.toggle("active", t.dataset.tab === S.centerTab);
+			});
+
+		switch (S.centerTab) {
+			case "overview":
+				renderOverview();
+				break;
+			case "terminal":
+				loadTerminal();
+				break;
+			case "trace":
+				loadTrace();
+				break;
+			case "agent-mail":
+				renderAgentMail();
+				break;
+		}
+	}
+
+	function renderOverview() {
+		const el = $("center-content");
+		const ins = S.inspect || {};
+		if (ins.error) {
+			el.innerHTML = `<div class="empty-state">${esc(ins.error)}</div>`;
+			return;
+		}
+		const session = ins.session || {};
+		const tokens = ins.tokenUsage || {};
+		const toolStats = Array.isArray(ins.toolStats) ? ins.toolStats : [];
+		const recent = Array.isArray(ins.recentToolCalls) ? ins.recentToolCalls.slice(0, 15) : [];
+
+		let html = '<div class="overview-grid">';
+
+		// Identity card
+		html += `<div class="ov-card">
+      <div class="ov-card-title">Session</div>
+      <div class="ov-row"><span class="label">Agent</span><span class="value">${esc(session.agent_name)}</span></div>
+      <div class="ov-row"><span class="label">Capability</span><span class="value">${esc(session.capability)}</span></div>
+      <div class="ov-row"><span class="label">State</span><span class="value"><span class="state-badge badge-${esc(session.state)}">${esc(session.state)}</span></span></div>
+      <div class="ov-row"><span class="label">Bead</span><span class="value">${esc(session.bead_id || "none")}</span></div>
+      <div class="ov-row"><span class="label">Branch</span><span class="value">${esc(session.branch_name || "none")}</span></div>
+      <div class="ov-row"><span class="label">Parent</span><span class="value">${esc(session.parent_agent || "none")}</span></div>
+      <div class="ov-row"><span class="label">Depth</span><span class="value">${session.depth ?? ""}</span></div>
+      <div class="ov-row"><span class="label">Duration</span><span class="value">${durFromDates(session.started_at)}</span></div>
+      <div class="ov-row"><span class="label">Started</span><span class="value">${timeAgo(session.started_at)}</span></div>
+      <div class="ov-row"><span class="label">Last Activity</span><span class="value">${timeAgo(session.last_activity)}</span></div>
+    </div>`;
+
+		// Token usage
+		if (tokens.input_tokens || tokens.output_tokens) {
+			html += `<div class="ov-card">
+        <div class="ov-card-title">Token Usage</div>
+        <div class="ov-row"><span class="label">Input</span><span class="value">${(tokens.input_tokens || 0).toLocaleString()}</span></div>
+        <div class="ov-row"><span class="label">Output</span><span class="value">${(tokens.output_tokens || 0).toLocaleString()}</span></div>
+        <div class="ov-row"><span class="label">Cache Read</span><span class="value">${(tokens.cache_read_tokens || 0).toLocaleString()}</span></div>
+        <div class="ov-row"><span class="label">Cache Write</span><span class="value">${(tokens.cache_creation_tokens || 0).toLocaleString()}</span></div>
+        <div class="ov-row"><span class="label">Est. Cost</span><span class="value">$${(tokens.estimated_cost_usd || 0).toFixed(3)}</span></div>
+        <div class="ov-row"><span class="label">Model</span><span class="value">${esc(tokens.model_used || "")}</span></div>
+      </div>`;
+		}
+
+		// Tool stats
+		if (toolStats.length) {
+			html += `<div class="ov-card">
+        <div class="ov-card-title">Tool Usage</div>
+        ${toolStats
+					.map(
+						(t) => `<div class="ov-row">
+          <span class="label">${esc(t.toolName || t.tool_name)}</span>
+          <span class="value">${t.count}x  avg ${dur(t.avgDuration || t.avg_duration || 0)}</span>
+        </div>`,
+					)
+					.join("")}
+      </div>`;
+		}
+
+		html += "</div>";
+
+		// Recent tool calls
+		if (recent.length) {
+			html +=
+				'<div style="margin-top:16px"><div class="ov-card-title" style="padding:0 0 8px">RECENT ACTIVITY</div>';
+			html += recent
+				.map((ev) => {
+					let detail = "";
+					if (ev.tool_args) {
+						try {
+							const args =
+								typeof ev.tool_args === "string" ? JSON.parse(ev.tool_args) : ev.tool_args;
+							detail = args.command || args.file_path || args.pattern || args.query || "";
+						} catch (_e) {
+							detail = "";
+						}
+					}
+					return `<div class="trace-item">
+          <span class="trace-time">${timeAgo(ev.created_at)}</span>
+          <span class="trace-type level-${esc(ev.level || "info")}">${esc(ev.event_type)}</span>
+          <span class="trace-tool">${esc(ev.tool_name || "")}</span>
+          <span class="trace-detail" title="${esc(detail)}">${esc(detail)}</span>
+          ${ev.tool_duration_ms ? `<span class="trace-dur">${dur(ev.tool_duration_ms)}</span>` : ""}
+        </div>`;
+				})
+				.join("");
+			html += "</div>";
+		}
+
+		el.innerHTML = html;
+	}
+
+	let activeTerminal = null;
+	let activeWs = null;
+	let activeResizeObserver = null;
+	let activeWindowResizeHandler = null;
+
+	function cleanupTerminal() {
+		if (activeWs) {
+			try {
+				activeWs.close();
+			} catch {}
+			activeWs = null;
+		}
+		if (activeTerminal) {
+			try {
+				activeTerminal.dispose();
+			} catch {}
+			activeTerminal = null;
+		}
+		if (activeResizeObserver) {
+			try {
+				activeResizeObserver.disconnect();
+			} catch {}
+			activeResizeObserver = null;
+		}
+		if (activeWindowResizeHandler) {
+			window.removeEventListener("resize", activeWindowResizeHandler);
+			activeWindowResizeHandler = null;
+		}
+	}
+
+	function loadTerminal() {
+		const el = $("center-content");
+		cleanupTerminal();
+
+		// If no agent selected, show start button
+		if (!S.selectedAgent) {
+			const hasOrchestrator =
+				Array.isArray(S.sessions) &&
+				S.sessions.some(
+					(s) =>
+						s.agent_name === "orchestrator" && ["working", "booting", "stalled"].includes(s.state),
+				);
+			if (hasOrchestrator) {
+				el.innerHTML =
+					'<div class="empty-state center-empty"><div class="empty-icon">&#x25C7;</div><div>Select an agent in the sidebar to view its terminal</div></div>';
+			} else {
+				el.innerHTML = `<div class="empty-state center-empty">
+          <div class="empty-icon">&#x25C7;</div>
+          <div>No orchestrator running</div>
+          <button class="start-orchestrator-btn" onclick="window._startOrchestrator()" style="margin-top:16px">Start Orchestrator</button>
+        </div>`;
+			}
+			return;
+		}
+
+		const session = S.sessions.find((s) => s.agent_name === S.selectedAgent);
+		const tmuxSession = session?.tmux_session;
+		const isActive = session && ["working", "booting", "stalled"].includes(session.state);
+
+		el.innerHTML = `<div class="xterm-wrap">
+      <div class="xterm-titlebar">
+        <div class="terminal-dots"><span></span><span></span><span></span></div>
+        <span class="terminal-session">${esc(S.selectedAgent)}${tmuxSession ? ` (${esc(tmuxSession)})` : ""}</span>
+      </div>
+      <div id="xterm-container"></div>
+    </div>`;
+
+		if (!tmuxSession || !isActive) {
+			const container = document.getElementById("xterm-container");
+			container.innerHTML =
+				'<div class="empty-state" style="padding:40px">No active tmux session for this agent</div>';
+			return;
+		}
+
+		const term = new Terminal({
+			fontFamily: "'JetBrains Mono NF', 'JetBrains Mono', monospace",
+			fontSize: 13,
+			lineHeight: 1,
+			customGlyphs: true,
+			cursorBlink: true,
+			allowProposedApi: true,
+			theme: {
+				background: "#11111b",
+				foreground: "#cdd6f4",
+				cursor: "#f5e0dc",
+				selectionBackground: "#45475a80",
+				black: "#45475a",
+				red: "#f38ba8",
+				green: "#a6e3a1",
+				yellow: "#f9e2af",
+				blue: "#89b4fa",
+				magenta: "#cba6f7",
+				cyan: "#94e2d5",
+				white: "#cdd6f4",
+				brightBlack: "#6c7086",
+				brightRed: "#f38ba8",
+				brightGreen: "#a6e3a1",
+				brightYellow: "#f9e2af",
+				brightBlue: "#89b4fa",
+				brightMagenta: "#f5c2e7",
+				brightCyan: "#89dcfe",
+				brightWhite: "#cdd6f4",
+			},
+		});
+
+		const fitAddon = new FitAddon.FitAddon();
+		term.loadAddon(fitAddon);
+		try {
+			const webLinksAddon = new WebLinksAddon.WebLinksAddon();
+			term.loadAddon(webLinksAddon);
+		} catch {}
+
+		const container = document.getElementById("xterm-container");
+		term.open(container);
+
+		const wsProto = location.protocol === "https:" ? "wss:" : "ws:";
+		const ws = new WebSocket(`${wsProto}//${location.host}/ws/terminal/${tmuxSession}`);
+
+		// Defer fit until layout settles, then send dimensions to server
+		requestAnimationFrame(() => {
+			fitAddon.fit();
+			if (ws.readyState === WebSocket.OPEN) {
+				ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
+			}
+		});
+
+		ws.onopen = () => {
+			// Re-fit in case layout changed between RAF and WS connect
+			fitAddon.fit();
+			ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
+		};
+
+		ws.onmessage = (e) => {
+			term.write(e.data);
+		};
+
+		term.onData((data) => {
+			if (ws.readyState === WebSocket.OPEN) ws.send(data);
+		});
+
+		term.onResize(({ cols, rows }) => {
+			if (ws.readyState === WebSocket.OPEN) {
+				ws.send(JSON.stringify({ type: "resize", cols, rows }));
+			}
+		});
+
+		const doFit = () => {
+			try {
+				fitAddon.fit();
+			} catch {}
+		};
+
+		const resizeObserver = new ResizeObserver(doFit);
+		resizeObserver.observe(container);
+		window.addEventListener("resize", doFit);
+
+		ws.onclose = () => {
+			term.write("\r\n\x1b[90m[Connection closed]\x1b[0m\r\n");
+		};
+
+		activeTerminal = term;
+		activeWs = ws;
+		activeResizeObserver = resizeObserver;
+		activeWindowResizeHandler = doFit;
+	}
+
+	async function loadTrace() {
+		const el = $("center-content");
+		if (!S.selectedAgent) return;
+		el.innerHTML = '<div class="empty-state">Loading trace...</div>';
+		const trace = await api(`/dash/api/trace/${S.selectedAgent}`);
+		S.trace = Array.isArray(trace) ? trace : [];
+		renderTrace();
+	}
+
+	function renderTrace() {
+		const el = $("center-content");
+		if (!S.trace.length) {
+			el.innerHTML = '<div class="empty-state">No events for this agent</div>';
+			return;
+		}
+		// Show newest first (already sorted DESC from server)
+		el.innerHTML = S.trace
+			.map((ev) => {
+				let detail = "";
+				if (ev.tool_args) {
+					try {
+						const args = typeof ev.tool_args === "string" ? JSON.parse(ev.tool_args) : ev.tool_args;
+						detail = args.command || args.file_path || args.pattern || args.query || "";
+					} catch (_e) {
+						detail = "";
+					}
+				} else if (ev.data) {
+					try {
+						const d = typeof ev.data === "string" ? JSON.parse(ev.data) : ev.data;
+						detail = d.message || d.reason || JSON.stringify(d).slice(0, 120);
+					} catch (_e) {
+						detail = "";
+					}
+				}
+				return `<div class="trace-item">
+        <span class="trace-time">${timeAgo(ev.created_at)}</span>
+        <span class="trace-type level-${esc(ev.level || "info")}">${esc(ev.event_type)}</span>
+        <span class="trace-tool">${esc(ev.tool_name || "")}</span>
+        <span class="trace-detail" title="${esc(detail)}">${esc(detail)}</span>
+        ${ev.tool_duration_ms ? `<span class="trace-dur">${dur(ev.tool_duration_ms)}</span>` : ""}
+      </div>`;
+			})
+			.join("");
+	}
+
+	function renderAgentMail() {
+		const el = $("center-content");
+		if (!S.agentMail.length) {
+			el.innerHTML = '<div class="empty-state">No messages for this agent</div>';
+			return;
+		}
+		el.innerHTML = S.agentMail.map((m) => mailCard(m, true)).join("");
+	}
+
+	// ── Right Panel ──
+
+	function renderRight() {
+		$("right-tabs")
+			.querySelectorAll(".tab")
+			.forEach((t) => {
+				t.classList.toggle("active", t.dataset.tab === S.rightTab);
+			});
+		switch (S.rightTab) {
+			case "inbox":
+				renderInbox();
+				break;
+			case "merge-queue":
+				renderMergeQueuePanel();
+				break;
+			case "events":
+				renderEventsPanel();
+				break;
+			case "metrics":
+				renderMetricsPanel();
+				break;
+			case "usage":
+				renderUsagePanel();
+				break;
+		}
+	}
+
+	function mailCard(m, expanded) {
+		const unread = m.read === 0 ? " unread" : "";
+		const priority = m.priority && m.priority !== "normal" ? ` priority-${m.priority}` : "";
+		const typeClass = `type-${m.type || "status"}`;
+		const exp = expanded ? " expanded" : "";
+		return `<div class="mail-item${unread}${priority}${exp}" onclick="this.classList.toggle('expanded')">
+      <div class="mail-header">
+        <span class="mail-route"><span class="from">${esc(m.from_agent)}</span> → <span class="to">${esc(m.to_agent)}</span></span>
+        <span class="mail-type ${typeClass}">${esc(m.type || "status")}</span>
+        <span class="mail-time">${timeAgo(m.created_at)}</span>
+      </div>
+      <div class="mail-subject">${esc(m.subject)}</div>
+      ${!expanded ? `<div class="mail-body-preview">${esc((m.body || "").slice(0, 100))}</div>` : ""}
+      <div class="mail-body">${esc(m.body || "")}</div>
+    </div>`;
+	}
+
+	function renderInbox() {
+		const el = $("right-content");
+		if (!Array.isArray(S.mail) || !S.mail.length) {
+			el.innerHTML = '<div class="empty-state">No messages</div>';
+			return;
+		}
+		el.innerHTML = S.mail.map((m) => mailCard(m, false)).join("");
+	}
+
+	function renderMergeQueuePanel() {
+		const el = $("right-content");
+		if (!Array.isArray(S.mergeQueue) || !S.mergeQueue.length) {
+			el.innerHTML = '<div class="empty-state">Merge queue empty</div>';
+			return;
+		}
+		el.innerHTML = S.mergeQueue
+			.map((m) => {
+				const statusCls = `merge-${m.status || "pending"}`;
+				let files = "";
+				if (m.files_modified) {
+					try {
+						const f =
+							typeof m.files_modified === "string"
+								? JSON.parse(m.files_modified)
+								: m.files_modified;
+						files = Array.isArray(f) ? `${f.length} files` : "";
+					} catch (_e) {
+						files = "";
+					}
+				}
+				return `<div class="merge-item">
+        <div class="merge-branch">${esc(m.branch_name)}</div>
+        <div class="merge-meta">
+          <span class="merge-status ${statusCls}">${esc(m.status)}</span>
+          <span>${esc(m.agent_name || "")}</span>
+          ${files ? `<span>${files}</span>` : ""}
+          <span>${timeAgo(m.enqueued_at)}</span>
+          ${m.resolved_tier ? `<span>${esc(m.resolved_tier)}</span>` : ""}
+        </div>
+      </div>`;
+			})
+			.join("");
+	}
+
+	function renderEventsPanel() {
+		const el = $("right-content");
+		if (!Array.isArray(S.events) || !S.events.length) {
+			el.innerHTML = '<div class="empty-state">No events</div>';
+			return;
+		}
+		el.innerHTML = S.events
+			.map((ev) => {
+				let detail = ev.tool_name || ev.event_type;
+				if (ev.data) {
+					try {
+						const d = typeof ev.data === "string" ? JSON.parse(ev.data) : ev.data;
+						if (d.message) detail += `: ${d.message}`;
+					} catch (_e) {}
+				}
+				return `<div class="event-item">
+        <span class="event-time">${timeAgo(ev.created_at)}</span>
+        <span class="event-level level-${esc(ev.level || "info")}">${esc(ev.level || "info")}</span>
+        <span class="event-agent">${esc(ev.agent_name)}</span>
+        <span class="event-detail">${esc(detail)}</span>
+      </div>`;
+			})
+			.join("");
+	}
+
+	function renderMetricsPanel() {
+		const el = $("right-content");
+		if (!Array.isArray(S.metrics) || !S.metrics.length) {
+			el.innerHTML = '<div class="empty-state">No metrics data</div>';
+			return;
+		}
+		const total = S.metrics.length;
+		const totalCost = S.metrics.reduce((s, m) => s + (m.estimated_cost_usd || 0), 0);
+		const totalInput = S.metrics.reduce((s, m) => s + (m.input_tokens || 0), 0);
+		const totalOutput = S.metrics.reduce((s, m) => s + (m.output_tokens || 0), 0);
+		const avgDur = S.metrics.reduce((s, m) => s + (m.duration_ms || 0), 0) / (total || 1);
+		const byCap = {};
+		S.metrics.forEach((m) => {
+			byCap[m.capability] = (byCap[m.capability] || 0) + 1;
+		});
+
+		let html = '<div class="metrics-grid">';
+		html += `<div class="metric-card"><div class="metric-val">${total}</div><div class="metric-label">Sessions</div></div>`;
+		html += `<div class="metric-card"><div class="metric-val">$${totalCost.toFixed(2)}</div><div class="metric-label">Total Cost</div></div>`;
+		html += `<div class="metric-card"><div class="metric-val">${dur(avgDur)}</div><div class="metric-label">Avg Duration</div></div>`;
+		html += `<div class="metric-card"><div class="metric-val">${(totalInput / 1000).toFixed(0)}k</div><div class="metric-label">Input Tokens</div></div>`;
+		html += `<div class="metric-card"><div class="metric-val">${(totalOutput / 1000).toFixed(0)}k</div><div class="metric-label">Output Tokens</div></div>`;
+		html += "</div>";
+
+		// By capability
+		html += '<div class="ov-card-title" style="padding:8px 0">BY CAPABILITY</div>';
+		html += '<div class="metrics-grid">';
+		for (const [cap, count] of Object.entries(byCap)) {
+			html += `<div class="metric-card"><div class="metric-val" style="font-size:18px">${count}</div><div class="metric-label"><span class="agent-cap cap-${esc(cap)}">${esc(cap)}</span></div></div>`;
+		}
+		html += "</div>";
+
+		// Session table
+		html += '<div class="ov-card-title" style="padding:12px 0 6px">SESSION HISTORY</div>';
+		html += `<table class="metrics-table">
+      <thead><tr><th>Agent</th><th>Cap</th><th>Duration</th><th>In Tokens</th><th>Out Tokens</th><th>Cost</th><th>Model</th></tr></thead>
+      <tbody>`;
+		for (const m of S.metrics.slice(0, 50)) {
+			html += `<tr>
+        <td>${esc(m.agent_name)}</td>
+        <td><span class="agent-cap cap-${esc(m.capability)}">${esc(m.capability)}</span></td>
+        <td>${dur(m.duration_ms)}</td>
+        <td>${(m.input_tokens || 0).toLocaleString()}</td>
+        <td>${(m.output_tokens || 0).toLocaleString()}</td>
+        <td>$${(m.estimated_cost_usd || 0).toFixed(3)}</td>
+        <td>${esc(m.model_used || "")}</td>
+      </tr>`;
+		}
+		html += "</tbody></table>";
+
+		el.innerHTML = html;
+	}
+
+	// ── Usage Panel ──
+
+	function modelShort(m) {
+		if (m.includes("opus")) return "Opus 4.6";
+		if (m.includes("sonnet")) return "Sonnet 4.6";
+		if (m.includes("haiku")) return "Haiku 4.5";
+		return m;
+	}
+
+	function modelBarClass(m) {
+		if (m.includes("opus")) return "model-opus";
+		if (m.includes("sonnet")) return "model-sonnet";
+		if (m.includes("haiku")) return "model-haiku";
+		return "model-sonnet";
+	}
+
+	function gaugeClass(pct) {
+		if (pct < 40) return "gauge-low";
+		if (pct < 65) return "gauge-mid";
+		if (pct < 85) return "gauge-high";
+		return "gauge-crit";
+	}
+
+	function gaugeColor(pct) {
+		if (pct < 40) return "var(--green)";
+		if (pct < 65) return "var(--yellow)";
+		if (pct < 85) return "var(--peach)";
+		return "var(--red)";
+	}
+
+	function fmtTokens(n) {
+		if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+		if (n >= 1_000) return `${(n / 1_000).toFixed(0)}k`;
+		return String(n);
+	}
+
+	function renderUsagePanel() {
+		const el = $("right-content");
+		const u = S.usage;
+		if (!u || u.error) {
+			el.innerHTML = `<div class="empty-state">${esc(u?.error || "Loading usage data...")}</div>`;
+			return;
+		}
+
+		const t = u.totals;
+		// Estimate usage percentage - rough heuristic based on weighted tokens
+		// Max 20x plan ~= 80M weighted tokens per 5h window (estimated)
+		const estimatedCap = 80_000_000;
+		const usagePct = Math.min(100, Math.round((t.weighted_tokens / estimatedCap) * 100));
+
+		let html = "";
+
+		// Window info
+		html += `<div class="usage-header">
+      <span class="usage-window-label">5-HOUR ROLLING WINDOW</span>
+      <span class="usage-window-val">${t.sessions} sessions &middot; ${t.requests} requests</span>
+    </div>`;
+
+		// Main gauge bar
+		html += `<div class="usage-gauge-wrap">
+      <div class="usage-gauge-label">
+        <span class="lbl">Estimated Quota Used</span>
+        <span class="pct" style="color:${gaugeColor(usagePct)}">${usagePct}%</span>
+      </div>
+      <div class="usage-gauge">
+        <div class="usage-gauge-fill ${gaugeClass(usagePct)}" style="width:${usagePct}%"></div>
+      </div>
+    </div>`;
+
+		// Summary cards
+		html += '<div class="metrics-grid">';
+		html += `<div class="metric-card"><div class="metric-val">${fmtTokens(t.raw_tokens)}</div><div class="metric-label">Raw Tokens</div></div>`;
+		html += `<div class="metric-card"><div class="metric-val">${fmtTokens(t.weighted_tokens)}</div><div class="metric-label">Weighted</div></div>`;
+		html += `<div class="metric-card"><div class="metric-val">$${t.api_cost_usd.toFixed(2)}</div><div class="metric-label">API Equiv.</div></div>`;
+		html += `<div class="metric-card"><div class="metric-val">${fmtTokens(t.cache_read_input_tokens)}</div><div class="metric-label">Cache Read</div></div>`;
+		html += "</div>";
+
+		// Per-model breakdown
+		const models = Object.entries(u.by_model).filter(([k]) => k !== "<synthetic>");
+		if (models.length) {
+			html += '<div class="ov-card-title" style="padding:8px 0">BY MODEL</div>';
+			html += '<div class="usage-models">';
+			const maxWeighted = Math.max(...models.map(([, v]) => v.weighted_tokens), 1);
+			for (const [model, m] of models) {
+				const barPct = Math.max(2, Math.round((m.weighted_tokens / maxWeighted) * 100));
+				html += `<div class="usage-model-row">
+          <span class="usage-model-name">${esc(modelShort(model))}</span>
+          <div class="usage-model-bar-wrap">
+            <div class="usage-model-bar ${modelBarClass(model)}" style="width:${barPct}%"></div>
+          </div>
+          <span class="usage-model-stats">
+            <span>${m.requests}req</span>
+            <span>${fmtTokens(m.input_tokens + m.output_tokens)}</span>
+            <span class="cost">$${m.api_cost_usd.toFixed(2)}</span>
+          </span>
+        </div>`;
+			}
+			html += "</div>";
+		}
+
+		// Sparkline - 15-minute buckets over 5 hours
+		const ts = u.time_series || [];
+		if (ts.length) {
+			const maxBucket = Math.max(...ts.map((b) => b.weighted), 1);
+			html += '<div class="usage-sparkline-wrap">';
+			html += '<div class="usage-sparkline-title">Activity (15-min buckets)</div>';
+			html += '<div class="usage-sparkline">';
+			for (let i = 0; i < ts.length; i++) {
+				const b = ts[i];
+				const h = Math.max(1, Math.round((b.weighted / maxBucket) * 48));
+				const isCurrent = i === ts.length - 1;
+				const title =
+					new Date(b.t).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }) +
+					": " +
+					fmtTokens(b.weighted) +
+					" weighted, " +
+					b.requests +
+					" req";
+				html += `<div class="spark-bar${isCurrent ? " current" : ""}" style="height:${h}px" title="${esc(title)}"></div>`;
+			}
+			html += "</div>";
+			// Labels
+			const first = ts[0]
+				? new Date(ts[0].t).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+				: "";
+			const last = ts[ts.length - 1]
+				? new Date(ts[ts.length - 1].t).toLocaleTimeString([], {
+						hour: "2-digit",
+						minute: "2-digit",
+					})
+				: "";
+			html += `<div class="sparkline-labels"><span>${first}</span><span>${last}</span></div>`;
+			html += "</div>";
+		}
+
+		// Raw token detail table
+		html += '<div class="ov-card-title" style="padding:8px 0">TOKEN DETAIL</div>';
+		html += `<table class="metrics-table">
+      <thead><tr><th>Model</th><th>Input</th><th>Output</th><th>Cache R</th><th>Cache W</th><th>Reqs</th></tr></thead>
+      <tbody>`;
+		for (const [model, m] of models) {
+			html += `<tr>
+        <td>${esc(modelShort(model))}</td>
+        <td>${fmtTokens(m.input_tokens)}</td>
+        <td>${fmtTokens(m.output_tokens)}</td>
+        <td>${fmtTokens(m.cache_read_input_tokens)}</td>
+        <td>${fmtTokens(m.cache_creation_input_tokens)}</td>
+        <td>${m.requests}</td>
+      </tr>`;
+		}
+		html += "</tbody></table>";
+
+		el.innerHTML = html;
+	}
+
+	function renderTopbarUsage() {
+		const u = S.usage;
+		if (!u || u.error) return;
+		const t = u.totals;
+		const estimatedCap = 80_000_000;
+		const usagePct = Math.min(100, Math.round((t.weighted_tokens / estimatedCap) * 100));
+		const existing = document.getElementById("topbar-usage");
+		if (existing) {
+			existing.querySelector(".topbar-usage-fill").style.width = `${usagePct}%`;
+			existing.querySelector(".topbar-usage-fill").className =
+				`topbar-usage-fill ${gaugeClass(usagePct)}`;
+			existing.querySelector(".topbar-usage-pct").textContent = `${usagePct}%`;
+			existing.querySelector(".topbar-usage-pct").style.color = gaugeColor(usagePct);
+			return;
+		}
+		const div = document.createElement("div");
+		div.id = "topbar-usage";
+		div.className = "topbar-usage";
+		div.innerHTML = `
+      <span class="topbar-usage-label">5h</span>
+      <div class="topbar-usage-bar">
+        <div class="topbar-usage-fill ${gaugeClass(usagePct)}" style="width:${usagePct}%"></div>
+      </div>
+      <span class="topbar-usage-pct" style="color:${gaugeColor(usagePct)}">${usagePct}%</span>
+    `;
+		const topRight = document.querySelector(".topbar-right");
+		topRight.insertBefore(div, topRight.firstChild);
+	}
+
+	// ── Main Loop ──
+
+	async function refresh() {
+		const dot = $("refresh-dot");
+		dot.classList.add("pulsing");
+		setTimeout(() => dot.classList.remove("pulsing"), 600);
+
+		const now = Date.now();
+
+		// Always fetch status + sessions
+		const [status, sessions] = await Promise.all([
+			api("/dash/api/status"),
+			api("/dash/api/sessions"),
+		]);
+		S.status = status.error ? {} : status;
+		S.sessions = Array.isArray(sessions) ? sessions : [];
+		renderSidebar();
+		renderStats();
+
+		// Refresh mail periodically
+		if (now - S.lastMailRefresh > MAIL_REFRESH) {
+			S.lastMailRefresh = now;
+			const [mail, mergeQueue, events] = await Promise.all([
+				api("/dash/api/mail?limit=100"),
+				api("/dash/api/merge-queue"),
+				api("/dash/api/events?limit=80"),
+			]);
+			S.mail = Array.isArray(mail) ? mail : [];
+			S.mergeQueue = Array.isArray(mergeQueue) ? mergeQueue : [];
+			S.events = Array.isArray(events) ? events : [];
+			renderRight();
+		}
+
+		// Refresh metrics less often
+		if (now - S.lastMetricsRefresh > METRICS_REFRESH) {
+			S.lastMetricsRefresh = now;
+			const [metrics, usage] = await Promise.all([
+				api("/dash/api/metrics"),
+				api("/dash/api/usage"),
+			]);
+			S.metrics = Array.isArray(metrics) ? metrics : [];
+			S.usage = usage && !usage.error ? usage : S.usage;
+			if (S.rightTab === "metrics" || S.rightTab === "usage") renderRight();
+			renderTopbarUsage();
+		}
+
+		// Fetch usage on first load if not loaded yet
+		if (!S.usage && now - S.lastUsageRefresh > 5000) {
+			S.lastUsageRefresh = now;
+			const usage = await api("/dash/api/usage");
+			S.usage = usage && !usage.error ? usage : null;
+			if (S.rightTab === "usage") renderRight();
+			renderTopbarUsage();
+		}
+
+		$("topbar-time").textContent = fmtTime();
+	}
+
+	// ── Tab Handlers ──
+
+	function setupTabs() {
+		$("center-tabs").addEventListener("click", (e) => {
+			const tab = e.target.closest(".tab");
+			if (!tab) return;
+			if (S.centerTab === "terminal" && tab.dataset.tab !== "terminal") cleanupTerminal();
+			S.centerTab = tab.dataset.tab;
+			renderCenter();
+		});
+
+		$("right-tabs").addEventListener("click", (e) => {
+			const tab = e.target.closest(".tab");
+			if (!tab) return;
+			S.rightTab = tab.dataset.tab;
+			// Force refresh of right panel data
+			S.lastMailRefresh = 0;
+			S.lastMetricsRefresh = 0;
+			renderRight();
+		});
+	}
+
+	// ── Init ──
+
+	function init() {
+		setupTabs();
+
+		// Clock toggle: click to switch 12h/24h
+		$("topbar-time").style.cursor = "pointer";
+		$("topbar-time").title = "Click to toggle 12h/24h";
+		$("topbar-time").addEventListener("click", () => {
+			S.use24h = !S.use24h;
+			$("topbar-time").textContent = fmtTime();
+		});
+
+		// Force immediate data load
+		S.lastMailRefresh = 0;
+		S.lastMetricsRefresh = 0;
+		refresh();
+		setInterval(refresh, REFRESH);
+	}
+
+	init();
+})();

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Overstory Dashboard</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link href="https://fonts.googleapis.com/css2?family=Exo+2:wght@400;500;600;700&family=JetBrains+Mono:ital,wght@0,400;0,500;0,600;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/dashboard/dashboard.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5/css/xterm.min.css">
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5/lib/xterm.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0/lib/addon-fit.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-web-links@0/lib/addon-web-links.min.js"></script>
+</head>
+<body>
+  <div class="dashboard">
+    <!-- Top status strip -->
+    <header class="topbar">
+      <div class="topbar-left">
+        <h1 class="logo">OVERSTORY</h1>
+        <span class="logo-sub">swarm dashboard</span>
+      </div>
+      <div class="topbar-stats" id="topbar-stats"></div>
+      <div class="topbar-right">
+        <div class="refresh-indicator" id="refresh-dot"></div>
+        <span class="topbar-time" id="topbar-time"></span>
+      </div>
+    </header>
+
+    <!-- Left sidebar: agent tree -->
+    <aside class="sidebar" id="sidebar">
+      <div class="sidebar-section-label">AGENTS</div>
+      <div class="agent-list" id="agent-list">
+        <div class="empty-state">Loading...</div>
+      </div>
+    </aside>
+
+    <!-- Center panel: agent detail -->
+    <main class="center" id="center">
+      <div class="center-header" id="center-header">
+        <div class="agent-identity" id="agent-identity">
+          <span class="empty-hint">Select an agent to inspect</span>
+        </div>
+        <div class="center-tabs" id="center-tabs">
+          <button type="button" class="tab active" data-tab="overview">Overview</button>
+          <button type="button" class="tab" data-tab="terminal">Terminal</button>
+          <button type="button" class="tab" data-tab="trace">Trace</button>
+          <button type="button" class="tab" data-tab="agent-mail">Mail</button>
+        </div>
+      </div>
+      <div class="center-content" id="center-content">
+        <div class="empty-state center-empty">
+          <div class="empty-icon">&#x25C7;</div>
+          <div>Click an agent in the sidebar to inspect it</div>
+        </div>
+      </div>
+    </main>
+
+    <!-- Right panel: mail, merges, events, metrics -->
+    <aside class="right-panel">
+      <div class="right-tabs" id="right-tabs">
+        <button type="button" class="tab active" data-tab="inbox">Mail</button>
+        <button type="button" class="tab" data-tab="merge-queue">Merges</button>
+        <button type="button" class="tab" data-tab="events">Events</button>
+        <button type="button" class="tab" data-tab="metrics">Metrics</button>
+        <button type="button" class="tab" data-tab="usage">Usage</button>
+      </div>
+      <div class="right-content" id="right-content">
+        <div class="empty-state">Loading...</div>
+      </div>
+    </aside>
+  </div>
+
+  <script src="/dashboard/dashboard.js"></script>
+</body>
+</html>

--- a/dashboard/usage.ts
+++ b/dashboard/usage.ts
@@ -1,0 +1,247 @@
+#!/usr/bin/env bun
+import { join } from "node:path";
+
+const CLAUDE_DIR = join(process.env.HOME ?? "", ".claude");
+const PROJECTS_DIR = join(CLAUDE_DIR, "projects");
+const WINDOW_MS = 5 * 60 * 60 * 1000; // 5 hours
+
+// Model weights for Max token accounting (Opus uses ~5x more quota than Sonnet)
+const MODEL_WEIGHTS: Record<string, number> = {
+	"claude-opus-4-6": 5,
+	"claude-opus-4-20250514": 5,
+	"claude-sonnet-4-6": 1,
+	"claude-sonnet-4-20250514": 1,
+	"claude-haiku-4-5-20251001": 0.2,
+};
+
+// API pricing per 1M tokens for cost estimation
+const API_PRICING: Record<
+	string,
+	{ input: number; output: number; cacheRead: number; cacheWrite: number }
+> = {
+	"claude-opus-4-6": { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
+	"claude-opus-4-20250514": { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
+	"claude-sonnet-4-6": { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+	"claude-sonnet-4-20250514": { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+	"claude-haiku-4-5-20251001": { input: 0.8, output: 4, cacheRead: 0.08, cacheWrite: 1 },
+};
+
+interface UsageEntry {
+	timestamp: string;
+	model: string;
+	input_tokens: number;
+	output_tokens: number;
+	cache_creation_input_tokens: number;
+	cache_read_input_tokens: number;
+	sessionId: string;
+	project: string;
+}
+
+interface ModelUsage {
+	input_tokens: number;
+	output_tokens: number;
+	cache_creation_input_tokens: number;
+	cache_read_input_tokens: number;
+	requests: number;
+	weighted_tokens: number;
+	api_cost_usd: number;
+}
+
+async function scanJsonlFile(
+	filePath: string,
+	cutoff: number,
+	project: string,
+): Promise<UsageEntry[]> {
+	const entries: UsageEntry[] = [];
+	try {
+		const content = await Bun.file(filePath).text();
+		const lines = content.split("\n");
+		for (const line of lines) {
+			if (!line.trim()) continue;
+			try {
+				const d = JSON.parse(line);
+				if (d.type !== "assistant") continue;
+				const ts = d.timestamp;
+				if (!ts) continue;
+				const tsMs = new Date(ts).getTime();
+				if (tsMs < cutoff) continue;
+				const usage = d.message?.usage;
+				if (!usage) continue;
+				entries.push({
+					timestamp: ts,
+					model: d.message?.model || "unknown",
+					input_tokens: usage.input_tokens || 0,
+					output_tokens: usage.output_tokens || 0,
+					cache_creation_input_tokens: usage.cache_creation_input_tokens || 0,
+					cache_read_input_tokens: usage.cache_read_input_tokens || 0,
+					sessionId: d.sessionId || "",
+					project,
+				});
+			} catch {
+				/* skip */
+			}
+		}
+	} catch {
+		/* skip */
+	}
+	return entries;
+}
+
+function computeApiCost(
+	model: string,
+	input: number,
+	output: number,
+	cacheRead: number,
+	cacheWrite: number,
+): number {
+	const pricing = API_PRICING[model] ?? API_PRICING["claude-sonnet-4-6"];
+	if (!pricing) return 0;
+	return (
+		(input / 1_000_000) * pricing.input +
+		(output / 1_000_000) * pricing.output +
+		(cacheRead / 1_000_000) * pricing.cacheRead +
+		(cacheWrite / 1_000_000) * pricing.cacheWrite
+	);
+}
+
+async function main() {
+	const projectRoot = process.argv[2];
+	if (!projectRoot) {
+		console.log(JSON.stringify({ error: "Project root required" }));
+		return;
+	}
+
+	const now = Date.now();
+	const cutoff = now - WINDOW_MS;
+	const allEntries: UsageEntry[] = [];
+
+	// Derive the Claude Code project directory name (path with / replaced by -)
+	const encodedPath = projectRoot.replace(/\//g, "-");
+	const targetDir = join(PROJECTS_DIR, encodedPath);
+
+	// Scan only the target project directory for JSONL files
+	try {
+		const glob = new Bun.Glob("*.jsonl");
+		for (const file of glob.scanSync(targetDir)) {
+			const filePath = join(targetDir, file);
+			// Quick check: skip files not modified in the last 5 hours
+			const bunFile = Bun.file(filePath);
+			if (bunFile.lastModified < cutoff) continue;
+			allEntries.push(...(await scanJsonlFile(filePath, cutoff, encodedPath)));
+		}
+	} catch {
+		// Directory not accessible or doesn't exist
+	}
+
+	// Aggregate by model
+	const byModel: Record<string, ModelUsage> = {};
+	let totalWeighted = 0;
+	let totalApiCost = 0;
+	let totalRequests = 0;
+
+	for (const entry of allEntries) {
+		if (!byModel[entry.model]) {
+			byModel[entry.model] = {
+				input_tokens: 0,
+				output_tokens: 0,
+				cache_creation_input_tokens: 0,
+				cache_read_input_tokens: 0,
+				requests: 0,
+				weighted_tokens: 0,
+				api_cost_usd: 0,
+			};
+		}
+		// biome-ignore lint: guaranteed by the block above
+		const m = byModel[entry.model]!;
+		m.input_tokens += entry.input_tokens;
+		m.output_tokens += entry.output_tokens;
+		m.cache_creation_input_tokens += entry.cache_creation_input_tokens;
+		m.cache_read_input_tokens += entry.cache_read_input_tokens;
+		m.requests++;
+
+		const weight = MODEL_WEIGHTS[entry.model] ?? 1;
+		const weighted = (entry.input_tokens + entry.output_tokens) * weight;
+		m.weighted_tokens += weighted;
+		totalWeighted += weighted;
+
+		const cost = computeApiCost(
+			entry.model,
+			entry.input_tokens,
+			entry.output_tokens,
+			entry.cache_read_input_tokens,
+			entry.cache_creation_input_tokens,
+		);
+		m.api_cost_usd += cost;
+		totalApiCost += cost;
+		totalRequests++;
+	}
+
+	// Unique sessions in window
+	const uniqueSessions = new Set(allEntries.map((e) => e.sessionId)).size;
+	const uniqueProjects = new Set(allEntries.map((e) => e.project)).size;
+
+	// Total raw tokens
+	const totalInput = allEntries.reduce((s, e) => s + e.input_tokens, 0);
+	const totalOutput = allEntries.reduce((s, e) => s + e.output_tokens, 0);
+	const totalCacheRead = allEntries.reduce((s, e) => s + e.cache_read_input_tokens, 0);
+	const totalCacheWrite = allEntries.reduce((s, e) => s + e.cache_creation_input_tokens, 0);
+
+	// Time series: bucket entries into 15-minute intervals for the last 5 hours
+	const BUCKET_MS = 15 * 60 * 1000;
+	const bucketCount = Math.ceil(WINDOW_MS / BUCKET_MS);
+	const timeSeries: Array<{ t: string; tokens: number; weighted: number; requests: number }> = [];
+	for (let i = 0; i < bucketCount; i++) {
+		const bucketStart = cutoff + i * BUCKET_MS;
+		const bucketEnd = bucketStart + BUCKET_MS;
+		const bucketEntries = allEntries.filter((e) => {
+			const t = new Date(e.timestamp).getTime();
+			return t >= bucketStart && t < bucketEnd;
+		});
+		const tokens = bucketEntries.reduce((s, e) => s + e.input_tokens + e.output_tokens, 0);
+		const weighted = bucketEntries.reduce((s, e) => {
+			const w = MODEL_WEIGHTS[e.model] || 1;
+			return s + (e.input_tokens + e.output_tokens) * w;
+		}, 0);
+		timeSeries.push({
+			t: new Date(bucketStart).toISOString(),
+			tokens,
+			weighted,
+			requests: bucketEntries.length,
+		});
+	}
+
+	// Oldest and newest entry in window
+	const sorted = allEntries.sort(
+		(a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+	);
+	const oldest = sorted[0]?.timestamp || null;
+	const newest = sorted[sorted.length - 1]?.timestamp || null;
+
+	const result = {
+		window: {
+			hours: 5,
+			cutoff: new Date(cutoff).toISOString(),
+			now: new Date(now).toISOString(),
+			oldest_entry: oldest,
+			newest_entry: newest,
+		},
+		totals: {
+			input_tokens: totalInput,
+			output_tokens: totalOutput,
+			cache_read_input_tokens: totalCacheRead,
+			cache_creation_input_tokens: totalCacheWrite,
+			raw_tokens: totalInput + totalOutput,
+			weighted_tokens: totalWeighted,
+			requests: totalRequests,
+			sessions: uniqueSessions,
+			projects: uniqueProjects,
+			api_cost_usd: Math.round(totalApiCost * 1000) / 1000,
+		},
+		by_model: byModel,
+		time_series: timeSeries,
+	};
+
+	console.log(JSON.stringify(result));
+}
+
+await main();

--- a/src/commands/completions.test.ts
+++ b/src/commands/completions.test.ts
@@ -13,7 +13,7 @@ import {
 
 describe("COMMANDS array", () => {
 	it("should have exactly 29 commands", () => {
-		expect(COMMANDS).toHaveLength(29);
+		expect(COMMANDS).toHaveLength(30);
 	});
 
 	it("should include all expected command names", () => {
@@ -31,6 +31,7 @@ describe("COMMANDS array", () => {
 		expect(names).toContain("doctor");
 		expect(names).toContain("log");
 		expect(names).toContain("watch");
+		expect(names).toContain("web");
 		expect(names).toContain("trace");
 		expect(names).toContain("errors");
 		expect(names).toContain("replay");

--- a/src/commands/completions.ts
+++ b/src/commands/completions.ts
@@ -222,6 +222,16 @@ export const COMMANDS: readonly CommandDef[] = [
 		],
 	},
 	{
+		name: "web",
+		desc: "Start web dashboard server",
+		flags: [
+			{ name: "--port", desc: "Port to listen on (default 3000)", takesValue: true },
+			{ name: "--background", desc: "Run in background" },
+			{ name: "--json", desc: "JSON output" },
+			{ name: "--help", desc: "Show help" },
+		],
+	},
+	{
 		name: "trace",
 		desc: "Chronological event timeline for agent/bead",
 		flags: [
@@ -605,7 +615,7 @@ export function generateBash(): string {
 		"  local cur prev words cword",
 		"  _init_completion || return",
 		"",
-		"  local commands='init sling prime status dashboard inspect merge nudge clean doctor log logs watch trace errors feed replay costs metrics spec coordinator supervisor hooks monitor mail group worktree run'",
+		"  local commands='init sling prime status dashboard inspect merge nudge clean doctor log logs watch web trace errors feed replay costs metrics spec coordinator supervisor hooks monitor mail group worktree run'",
 		"",
 		"  # Top-level completion",
 		"  if [[ $cword -eq 1 ]]; then",

--- a/src/commands/web.test.ts
+++ b/src/commands/web.test.ts
@@ -1,0 +1,497 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startServer, webCommand } from "./web.ts";
+
+/**
+ * Tests for `overstory web` command.
+ *
+ * Two test suites:
+ * 1. webCommand — CLI-level tests (help, port validation, background mode)
+ * 2. startServer — integration tests using ephemeral ports with real HTTP requests
+ */
+
+describe("webCommand", () => {
+	let chunks: string[];
+	let stderrChunks: string[];
+	let originalWrite: typeof process.stdout.write;
+	let originalStderrWrite: typeof process.stderr.write;
+	let tempDir: string;
+	let originalCwd: string;
+	let originalExitCode: string | number | null | undefined;
+
+	beforeEach(async () => {
+		// Spy on stdout
+		chunks = [];
+		originalWrite = process.stdout.write;
+		process.stdout.write = ((chunk: string) => {
+			chunks.push(chunk);
+			return true;
+		}) as typeof process.stdout.write;
+
+		// Spy on stderr
+		stderrChunks = [];
+		originalStderrWrite = process.stderr.write;
+		process.stderr.write = ((chunk: string) => {
+			stderrChunks.push(chunk);
+			return true;
+		}) as typeof process.stderr.write;
+
+		// Save original exitCode
+		originalExitCode = process.exitCode;
+		process.exitCode = 0;
+
+		// Create temp dir with .overstory/config.yaml structure
+		tempDir = await mkdtemp(join(tmpdir(), "web-test-"));
+		const overstoryDir = join(tempDir, ".overstory");
+		await Bun.write(
+			join(overstoryDir, "config.yaml"),
+			`project:\n  name: test\n  root: ${tempDir}\n  canonicalBranch: main\n`,
+		);
+
+		// Change to temp dir so loadConfig() works
+		originalCwd = process.cwd();
+		process.chdir(tempDir);
+	});
+
+	afterEach(async () => {
+		process.stdout.write = originalWrite;
+		process.stderr.write = originalStderrWrite;
+		process.exitCode = originalExitCode;
+		process.chdir(originalCwd);
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	function output(): string {
+		return chunks.join("");
+	}
+
+	function stderr(): string {
+		return stderrChunks.join("");
+	}
+
+	test("--help flag shows help text with key info", async () => {
+		await webCommand(["--help"]);
+		const out = output();
+
+		expect(out).toContain("overstory web");
+		expect(out).toContain("--port");
+		expect(out).toContain("--background");
+		expect(out).toContain("--json");
+		expect(out).toContain("--help");
+	});
+
+	test("-h flag shows help text", async () => {
+		await webCommand(["-h"]);
+		const out = output();
+
+		expect(out).toContain("overstory web");
+		expect(out).toContain("--port");
+	});
+
+	test("invalid port: NaN", async () => {
+		await webCommand(["--port", "abc"]);
+
+		const err = stderr();
+		expect(err).toContain("Invalid port");
+		expect(err).toContain("abc");
+		expect(process.exitCode).toBe(1);
+	});
+
+	test("invalid port: out of range (0)", async () => {
+		await webCommand(["--port", "0"]);
+
+		const err = stderr();
+		expect(err).toContain("Invalid port");
+		expect(process.exitCode).toBe(1);
+	});
+
+	test("invalid port: out of range (99999)", async () => {
+		await webCommand(["--port", "99999"]);
+
+		const err = stderr();
+		expect(err).toContain("Invalid port");
+		expect(process.exitCode).toBe(1);
+	});
+
+	test("background mode: already running detection", async () => {
+		// Write a PID file with a running process (use our own PID)
+		const pidFilePath = join(tempDir, ".overstory", "web.pid");
+		await Bun.write(pidFilePath, `${process.pid}\n`);
+
+		// Try to start in background mode — should fail with "already running"
+		await webCommand(["--background"]);
+
+		const err = stderr();
+		expect(err).toContain("already running");
+		expect(err).toContain(`${process.pid}`);
+		expect(process.exitCode).toBe(1);
+	});
+
+	test("background mode: stale PID cleanup", async () => {
+		// Write a PID file with a non-running process (999999 is very unlikely to exist)
+		const pidFilePath = join(tempDir, ".overstory", "web.pid");
+		await Bun.write(pidFilePath, "999999\n");
+
+		// Verify the stale PID file exists before the test
+		const fileBeforeExists = await Bun.file(pidFilePath).exists();
+		expect(fileBeforeExists).toBe(true);
+
+		// Try to start in background mode
+		// This will clean up the stale PID file, then attempt to spawn.
+		// The spawn will fail because there's no real overstory binary in test env,
+		// but the important part is that the stale PID file gets removed.
+		try {
+			await webCommand(["--background"]);
+		} catch {
+			// Expected to fail when trying to spawn — that's OK
+		}
+
+		// The stale PID file should have been removed during the check
+		// (Even if the spawn itself failed, the cleanup happens before spawn)
+		// Actually, looking at the code: if existingPid is not null but not running,
+		// it removes the PID file. Then it tries to spawn. So the file should be gone
+		// OR replaced with a new PID.
+
+		// Let's check: the file should either not exist, OR contain a different PID
+		const fileAfterExists = await Bun.file(pidFilePath).exists();
+		if (fileAfterExists) {
+			const content = await Bun.file(pidFilePath).text();
+			expect(content.trim()).not.toBe("999999");
+		}
+		// If it doesn't exist, that's also valid (spawn failed before writing new PID)
+	});
+});
+
+// ── Integration tests: real HTTP requests against startServer() ──
+
+/**
+ * Create minimal SQLite databases matching the schemas used by handleDashApi.
+ */
+function seedTestDatabases(overstoryDir: string): void {
+	// sessions.db
+	const sessionsDb = new Database(join(overstoryDir, "sessions.db"));
+	sessionsDb.exec(`
+		CREATE TABLE sessions (
+			id TEXT PRIMARY KEY,
+			agent_name TEXT NOT NULL UNIQUE,
+			capability TEXT NOT NULL,
+			worktree_path TEXT NOT NULL,
+			branch_name TEXT NOT NULL,
+			bead_id TEXT NOT NULL,
+			tmux_session TEXT NOT NULL,
+			state TEXT NOT NULL DEFAULT 'booting',
+			pid INTEGER,
+			parent_agent TEXT,
+			depth INTEGER NOT NULL DEFAULT 0,
+			run_id TEXT,
+			started_at TEXT NOT NULL,
+			last_activity TEXT NOT NULL,
+			escalation_level INTEGER NOT NULL DEFAULT 0,
+			stalled_since TEXT
+		)
+	`);
+	sessionsDb.exec(`
+		INSERT INTO sessions (id, agent_name, capability, worktree_path, branch_name, bead_id, tmux_session, state, started_at, last_activity)
+		VALUES ('sess-1', 'test-builder', 'builder', '/tmp/wt', 'feat/test', 'bead-1', 'overstory-test-fake', 'working', '2025-01-01T00:00:00', '2025-01-01T00:01:00')
+	`);
+	sessionsDb.close();
+
+	// mail.db
+	const mailDb = new Database(join(overstoryDir, "mail.db"));
+	mailDb.exec(`
+		CREATE TABLE messages (
+			id TEXT PRIMARY KEY,
+			from_agent TEXT NOT NULL,
+			to_agent TEXT NOT NULL,
+			subject TEXT NOT NULL,
+			body TEXT NOT NULL,
+			type TEXT NOT NULL DEFAULT 'status',
+			priority TEXT NOT NULL DEFAULT 'normal',
+			thread_id TEXT,
+			payload TEXT,
+			read INTEGER NOT NULL DEFAULT 0,
+			created_at TEXT NOT NULL DEFAULT (datetime('now'))
+		)
+	`);
+	mailDb.exec(`
+		INSERT INTO messages (id, from_agent, to_agent, subject, body, type, created_at)
+		VALUES ('msg-1', 'builder-a', 'orchestrator', 'Done', 'Task complete', 'result', '2025-01-01T00:00:00')
+	`);
+	mailDb.close();
+
+	// events.db
+	const eventsDb = new Database(join(overstoryDir, "events.db"));
+	eventsDb.exec(`
+		CREATE TABLE events (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			run_id TEXT,
+			agent_name TEXT NOT NULL,
+			session_id TEXT,
+			event_type TEXT NOT NULL,
+			tool_name TEXT,
+			tool_args TEXT,
+			tool_duration_ms INTEGER,
+			level TEXT NOT NULL DEFAULT 'info',
+			data TEXT,
+			created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f','now'))
+		)
+	`);
+	eventsDb.exec(`
+		INSERT INTO events (agent_name, event_type, level, created_at)
+		VALUES ('test-builder', 'tool-end', 'info', '2025-01-01T00:00:00')
+	`);
+	eventsDb.exec(`
+		INSERT INTO events (agent_name, event_type, level, created_at)
+		VALUES ('test-builder', 'error', 'error', '2025-01-01T00:00:01')
+	`);
+	eventsDb.close();
+
+	// merge-queue.db
+	const mqDb = new Database(join(overstoryDir, "merge-queue.db"));
+	mqDb.exec(`
+		CREATE TABLE merge_queue (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			branch_name TEXT NOT NULL,
+			bead_id TEXT NOT NULL,
+			agent_name TEXT NOT NULL,
+			files_modified TEXT NOT NULL DEFAULT '[]',
+			enqueued_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f','now')),
+			status TEXT NOT NULL DEFAULT 'pending',
+			resolved_tier TEXT
+		)
+	`);
+	mqDb.close();
+
+	// metrics.db
+	const metricsDb = new Database(join(overstoryDir, "metrics.db"));
+	metricsDb.exec(`
+		CREATE TABLE sessions (
+			agent_name TEXT NOT NULL,
+			bead_id TEXT NOT NULL,
+			capability TEXT NOT NULL,
+			started_at TEXT NOT NULL,
+			completed_at TEXT,
+			duration_ms INTEGER NOT NULL DEFAULT 0,
+			exit_code INTEGER,
+			merge_result TEXT,
+			parent_agent TEXT,
+			input_tokens INTEGER NOT NULL DEFAULT 0,
+			output_tokens INTEGER NOT NULL DEFAULT 0,
+			cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+			cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+			estimated_cost_usd REAL,
+			model_used TEXT,
+			PRIMARY KEY (agent_name, bead_id)
+		)
+	`);
+	metricsDb.close();
+}
+
+describe("startServer integration", () => {
+	let tempDir: string;
+	let server: ReturnType<typeof Bun.serve>;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "web-int-"));
+		const overstoryDir = join(tempDir, ".overstory");
+		await Bun.write(
+			join(overstoryDir, "config.yaml"),
+			`project:\n  name: test\n  root: ${tempDir}\n  canonicalBranch: main\n`,
+		);
+		seedTestDatabases(overstoryDir);
+		server = startServer(0, tempDir);
+	});
+
+	afterEach(() => {
+		server.stop(true);
+	});
+
+	function url(path: string): string {
+		return `http://localhost:${server.port}${path}`;
+	}
+
+	// ── API endpoint tests ──
+
+	test("GET /dash/api/sessions returns session data", async () => {
+		const res = await fetch(url("/dash/api/sessions"));
+		expect(res.status).toBe(200);
+		expect(res.headers.get("content-type")).toBe("application/json");
+		const data = (await res.json()) as Array<Record<string, unknown>>;
+		expect(data).toBeArray();
+		expect(data.length).toBe(1);
+		expect(data[0]?.agent_name).toBe("test-builder");
+		expect(data[0]?.state).toBe("working");
+	});
+
+	test("GET /dash/api/mail returns messages", async () => {
+		const res = await fetch(url("/dash/api/mail"));
+		expect(res.status).toBe(200);
+		const data = (await res.json()) as Array<Record<string, unknown>>;
+		expect(data).toBeArray();
+		expect(data.length).toBe(1);
+		expect(data[0]?.from_agent).toBe("builder-a");
+	});
+
+	test("GET /dash/api/mail/:id returns specific message", async () => {
+		const res = await fetch(url("/dash/api/mail/msg-1"));
+		expect(res.status).toBe(200);
+		const data = (await res.json()) as Array<Record<string, unknown>>;
+		expect(data).toBeArray();
+		expect(data.length).toBe(1);
+		expect(data[0]?.id).toBe("msg-1");
+	});
+
+	test("GET /dash/api/mail with filters", async () => {
+		const res = await fetch(url("/dash/api/mail?from=builder-a&limit=10"));
+		expect(res.status).toBe(200);
+		const data = (await res.json()) as Array<Record<string, unknown>>;
+		expect(data.length).toBe(1);
+
+		// Non-matching filter
+		const res2 = await fetch(url("/dash/api/mail?from=nobody"));
+		const data2 = (await res2.json()) as Array<Record<string, unknown>>;
+		expect(data2.length).toBe(0);
+	});
+
+	test("GET /dash/api/events returns events", async () => {
+		const res = await fetch(url("/dash/api/events"));
+		expect(res.status).toBe(200);
+		const data = (await res.json()) as Array<Record<string, unknown>>;
+		expect(data).toBeArray();
+		expect(data.length).toBe(2);
+	});
+
+	test("GET /dash/api/events with level filter", async () => {
+		const res = await fetch(url("/dash/api/events?level=error"));
+		expect(res.status).toBe(200);
+		const data = (await res.json()) as Array<Record<string, unknown>>;
+		expect(data.length).toBe(1);
+		expect(data[0]?.level).toBe("error");
+	});
+
+	test("GET /dash/api/errors returns only error-level events", async () => {
+		const res = await fetch(url("/dash/api/errors"));
+		expect(res.status).toBe(200);
+		const data = (await res.json()) as Array<Record<string, unknown>>;
+		expect(data.length).toBe(1);
+		expect(data[0]?.level).toBe("error");
+	});
+
+	test("GET /dash/api/trace/:agent returns agent events", async () => {
+		const res = await fetch(url("/dash/api/trace/test-builder"));
+		expect(res.status).toBe(200);
+		const data = (await res.json()) as Array<Record<string, unknown>>;
+		expect(data.length).toBe(2);
+	});
+
+	test("GET /dash/api/trace without agent returns error", async () => {
+		const res = await fetch(url("/dash/api/trace"));
+		// Route splits on "/" — empty param → error response
+		const data = (await res.json()) as Record<string, unknown>;
+		expect(data.error).toBe("Agent name required");
+	});
+
+	test("GET /dash/api/merge-queue returns empty array", async () => {
+		const res = await fetch(url("/dash/api/merge-queue"));
+		expect(res.status).toBe(200);
+		const data = (await res.json()) as unknown[];
+		expect(data).toEqual([]);
+	});
+
+	test("GET /dash/api/metrics returns empty array", async () => {
+		const res = await fetch(url("/dash/api/metrics"));
+		expect(res.status).toBe(200);
+		const data = (await res.json()) as unknown[];
+		expect(data).toEqual([]);
+	});
+
+	test("GET /dash/api/unknown returns 404", async () => {
+		const res = await fetch(url("/dash/api/nonexistent"));
+		expect(res.status).toBe(404);
+		const data = (await res.json()) as Record<string, unknown>;
+		expect(data.error).toBe("Unknown endpoint");
+	});
+
+	// ── Missing database resilience ──
+
+	test("API returns empty array when database is missing", async () => {
+		// Create a server with a root that has no databases
+		const emptyDir = await mkdtemp(join(tmpdir(), "web-empty-"));
+		const emptyServer = startServer(0, emptyDir);
+		try {
+			const res = await fetch(`http://localhost:${emptyServer.port}/dash/api/sessions`);
+			expect(res.status).toBe(200);
+			const data = (await res.json()) as unknown[];
+			expect(data).toEqual([]);
+		} finally {
+			emptyServer.stop(true);
+			await rm(emptyDir, { recursive: true, force: true });
+		}
+	});
+
+	// ── Static file serving ──
+
+	test("GET / serves index.html", async () => {
+		const res = await fetch(url("/"));
+		// The dashboard/index.html exists in the repo, so this should succeed
+		expect(res.status).toBe(200);
+		expect(res.headers.get("content-type")).toBe("text/html");
+	});
+
+	// ── Path traversal protection ──
+
+	test("path traversal attempts don't serve files outside dashboard", async () => {
+		// fetch() normalizes ../ before sending, so the server sees /etc/passwd
+		// which resolves inside dashboardDir → 404 (file not found). The resolve()
+		// check catches any path that escapes the dashboard directory.
+		const res = await fetch(url("/dashboard/../../../etc/passwd"));
+		expect([403, 404]).toContain(res.status);
+
+		// Encoded traversal attempt
+		const res2 = await fetch(url("/dashboard/%2e%2e/%2e%2e/etc/passwd"));
+		expect([403, 404]).toContain(res2.status);
+
+		// Direct path outside dashboard
+		const res3 = await fetch(url("/etc/passwd"));
+		expect([403, 404]).toContain(res3.status);
+	});
+
+	// ── WebSocket upgrade ──
+
+	test("WebSocket upgrade to /ws/terminal/<session> succeeds", async () => {
+		const ws = new WebSocket(`ws://localhost:${server.port}/ws/terminal/test-session`);
+		const opened = await new Promise<boolean>((resolve) => {
+			ws.onopen = () => resolve(true);
+			ws.onerror = () => resolve(false);
+			setTimeout(() => resolve(false), 2000);
+		});
+		expect(opened).toBe(true);
+		ws.close();
+	});
+
+	test("WebSocket upgrade with invalid session name returns 400", async () => {
+		const res = await fetch(url("/ws/terminal/bad%20session%21"), {
+			headers: { Upgrade: "websocket" },
+		});
+		// safe() strips invalid chars → empty → 400
+		expect(res.status).toBe(400);
+	});
+
+	test("WebSocket upgrade without session name returns 400", async () => {
+		const res = await fetch(url("/ws/terminal/"), {
+			headers: { Upgrade: "websocket" },
+		});
+		expect([400, 404]).toContain(res.status);
+	});
+
+	// ── Trailing slash normalization ──
+
+	test("trailing slash is normalized", async () => {
+		const res = await fetch(url("/dash/api/sessions/"));
+		// "sessions/" → route="sessions/" → cmd="sessions" after split
+		expect(res.status).toBe(200);
+	});
+});

--- a/src/commands/web.ts
+++ b/src/commands/web.ts
@@ -1,0 +1,850 @@
+/**
+ * CLI command: overstory web [--port <port>] [--background]
+ *
+ * Starts the Overstory web dashboard server using Bun.serve() with native WebSocket support.
+ * Background mode spawns a detached process via Bun.spawn and writes a PID file.
+ * Default port is 3000.
+ */
+
+import { Database } from "bun:sqlite";
+import { join, resolve } from "node:path";
+import { loadConfig } from "../config.ts";
+import { OverstoryError } from "../errors.ts";
+import { isProcessRunning } from "../watchdog/health.ts";
+
+/**
+ * Parse a named flag value from args.
+ */
+function getFlag(args: string[], flag: string): string | undefined {
+	const idx = args.indexOf(flag);
+	if (idx === -1 || idx + 1 >= args.length) {
+		return undefined;
+	}
+	return args[idx + 1];
+}
+
+function hasFlag(args: string[], flag: string): boolean {
+	return args.includes(flag);
+}
+
+/**
+ * Read the PID from the web server PID file.
+ * Returns null if the file doesn't exist or can't be parsed.
+ */
+async function readPidFile(pidFilePath: string): Promise<number | null> {
+	const file = Bun.file(pidFilePath);
+	const exists = await file.exists();
+	if (!exists) {
+		return null;
+	}
+
+	try {
+		const text = await file.text();
+		const pid = Number.parseInt(text.trim(), 10);
+		if (Number.isNaN(pid) || pid <= 0) {
+			return null;
+		}
+		return pid;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Write a PID to the web server PID file.
+ */
+async function writePidFile(pidFilePath: string, pid: number): Promise<void> {
+	await Bun.write(pidFilePath, `${pid}\n`);
+}
+
+/**
+ * Remove the web server PID file.
+ */
+async function removePidFile(pidFilePath: string): Promise<void> {
+	const { unlink } = await import("node:fs/promises");
+	try {
+		await unlink(pidFilePath);
+	} catch {
+		// File may already be gone — not an error
+	}
+}
+
+/**
+ * Resolve the path to the overstory binary for re-launching.
+ * Uses `which overstory` first, then falls back to process.argv.
+ */
+async function resolveOverstoryBin(): Promise<string> {
+	try {
+		const proc = Bun.spawn(["which", "overstory"], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const exitCode = await proc.exited;
+		if (exitCode === 0) {
+			const binPath = (await new Response(proc.stdout).text()).trim();
+			if (binPath.length > 0) {
+				return binPath;
+			}
+		}
+	} catch {
+		// which not available or overstory not on PATH
+	}
+
+	// Fallback: use the script that's currently running (process.argv[1])
+	const scriptPath = process.argv[1];
+	if (scriptPath) {
+		return scriptPath;
+	}
+
+	throw new OverstoryError(
+		"Cannot resolve overstory binary path for background launch",
+		"WEB_ERROR",
+	);
+}
+
+// ── Dashboard API helpers ──
+
+/**
+ * Sanitize a string to allow only safe identifier characters.
+ */
+function safe(str: string | null | undefined): string {
+	if (!str || typeof str !== "string") return "";
+	return str.replace(/[^a-zA-Z0-9_\-.]/g, "");
+}
+
+const MIME: Record<string, string> = {
+	".html": "text/html",
+	".css": "text/css",
+	".js": "application/javascript",
+	".json": "application/json",
+	".png": "image/png",
+	".jpg": "image/jpeg",
+	".gif": "image/gif",
+	".svg": "image/svg+xml",
+	".wav": "audio/wav",
+	".mp3": "audio/mpeg",
+	".ogg": "audio/ogg",
+	".ico": "image/x-icon",
+	".woff2": "font/woff2",
+	".woff": "font/woff",
+	".ttf": "font/ttf",
+};
+
+/**
+ * Open a SQLite database in readonly mode. Returns null if the file doesn't exist.
+ */
+function openReadonlyDb(root: string, dbFile: string): Database | null {
+	const dbPath = join(root, ".overstory", dbFile);
+	try {
+		return new Database(dbPath, { readonly: true });
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Execute an overstory CLI command and parse the JSON output.
+ */
+async function execOs(root: string, cmd: string[]): Promise<unknown> {
+	try {
+		const proc = Bun.spawn(cmd, {
+			cwd: root,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		await proc.exited;
+		const raw = (await new Response(proc.stdout).text()).trim();
+		return raw ? (JSON.parse(raw) as unknown) : {};
+	} catch (e: unknown) {
+		return { error: e instanceof Error ? e.message : String(e) };
+	}
+}
+
+/**
+ * Handle all /dash/api/* routes.
+ */
+async function handleDashApi(urlPath: string, fullUrl: string, root: string): Promise<Response> {
+	const route = urlPath.replace("/dash/api/", "");
+	const [cmd, ...rest] = route.split("/");
+	const param = safe(rest.join("/"));
+	const url = new URL(fullUrl, "http://localhost");
+
+	const jsonResponse = (data: unknown): Response =>
+		new Response(JSON.stringify(data), {
+			headers: { "Content-Type": "application/json", "Cache-Control": "no-cache" },
+		});
+
+	switch (cmd) {
+		case "status":
+			return jsonResponse(await execOs(root, ["overstory", "status", "--json"]));
+
+		case "sessions": {
+			const db = openReadonlyDb(root, "sessions.db");
+			if (!db) return jsonResponse([]);
+			try {
+				return jsonResponse(
+					db
+						.prepare(
+							"SELECT * FROM sessions ORDER BY CASE WHEN state IN ('working','booting','stalled') THEN 0 ELSE 1 END, started_at DESC",
+						)
+						.all(),
+				);
+			} finally {
+				db.close();
+			}
+		}
+
+		case "mail": {
+			const db = openReadonlyDb(root, "mail.db");
+			if (!db) return jsonResponse([]);
+			try {
+				if (param) {
+					return jsonResponse(
+						db.prepare("SELECT * FROM messages WHERE id = $id").all({ $id: param }),
+					);
+				}
+				const from = safe(url.searchParams.get("from"));
+				const to = safe(url.searchParams.get("to"));
+				const agent = safe(url.searchParams.get("agent"));
+				const limitRaw = Number.parseInt(url.searchParams.get("limit") ?? "100", 10);
+				const limit = Math.min(Number.isNaN(limitRaw) ? 100 : limitRaw, 500);
+				const conditions: string[] = [];
+				const params: Record<string, string | number> = {};
+				if (from) {
+					conditions.push("from_agent = $from");
+					params.$from = from;
+				}
+				if (to) {
+					conditions.push("to_agent = $to");
+					params.$to = to;
+				}
+				if (agent) {
+					conditions.push("(from_agent = $agent OR to_agent = $agent)");
+					params.$agent = agent;
+				}
+				if (url.searchParams.get("unread") === "true") {
+					conditions.push("read = 0");
+				}
+				const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+				params.$limit = limit;
+				return jsonResponse(
+					db
+						.prepare(`SELECT * FROM messages ${whereClause} ORDER BY created_at DESC LIMIT $limit`)
+						.all(params),
+				);
+			} finally {
+				db.close();
+			}
+		}
+
+		case "inspect":
+			if (!param) return jsonResponse({ error: "Agent name required" });
+			return jsonResponse(await execOs(root, ["overstory", "inspect", param, "--json"]));
+
+		case "trace": {
+			if (!param) return jsonResponse({ error: "Agent name required" });
+			const db = openReadonlyDb(root, "events.db");
+			if (!db) return jsonResponse([]);
+			try {
+				return jsonResponse(
+					db
+						.prepare(
+							"SELECT * FROM events WHERE agent_name = $agent_name ORDER BY created_at DESC LIMIT 200",
+						)
+						.all({ $agent_name: param }),
+				);
+			} finally {
+				db.close();
+			}
+		}
+
+		case "tmux": {
+			if (!param) {
+				return new Response("Agent name required", { status: 400 });
+			}
+			const db = openReadonlyDb(root, "sessions.db");
+			if (!db) {
+				return new Response("[No active tmux session]", {
+					headers: { "Content-Type": "text/plain" },
+				});
+			}
+			let tmuxSession: string | undefined;
+			try {
+				const row = db
+					.prepare<{ tmux_session: string }, { $agent_name: string }>(
+						"SELECT tmux_session FROM sessions WHERE agent_name = $agent_name AND state IN ('working','booting','stalled')",
+					)
+					.get({ $agent_name: param });
+				tmuxSession = row?.tmux_session;
+			} catch (e: unknown) {
+				return new Response(`[Error: ${e instanceof Error ? e.message : String(e)}]`, {
+					headers: { "Content-Type": "text/plain" },
+				});
+			} finally {
+				db.close();
+			}
+
+			if (tmuxSession) {
+				const safeSession = safe(tmuxSession);
+				const proc = Bun.spawn(["tmux", "capture-pane", "-t", safeSession, "-p", "-S", "-500"], {
+					stdout: "pipe",
+					stderr: "pipe",
+				});
+				await proc.exited;
+				const pane = await new Response(proc.stdout).text();
+				return new Response(pane || "[Session not active]", {
+					headers: { "Content-Type": "text/plain", "Cache-Control": "no-cache" },
+				});
+			}
+			return new Response("[No active tmux session]", {
+				headers: { "Content-Type": "text/plain" },
+			});
+		}
+
+		case "merge-queue": {
+			const db = openReadonlyDb(root, "merge-queue.db");
+			if (!db) return jsonResponse([]);
+			try {
+				return jsonResponse(db.prepare("SELECT * FROM merge_queue ORDER BY id DESC").all());
+			} finally {
+				db.close();
+			}
+		}
+
+		case "events": {
+			const evLimitRaw = Number.parseInt(url.searchParams.get("limit") ?? "100", 10);
+			const evLimit = Math.min(Number.isNaN(evLimitRaw) ? 100 : evLimitRaw, 500);
+			const level = safe(url.searchParams.get("level"));
+			const db = openReadonlyDb(root, "events.db");
+			if (!db) return jsonResponse([]);
+			try {
+				const conditions: string[] = [];
+				const params: Record<string, string | number> = {};
+				if (level) {
+					conditions.push("level = $level");
+					params.$level = level;
+				}
+				const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+				params.$limit = evLimit;
+				return jsonResponse(
+					db
+						.prepare(`SELECT * FROM events ${whereClause} ORDER BY created_at DESC LIMIT $limit`)
+						.all(params),
+				);
+			} finally {
+				db.close();
+			}
+		}
+
+		case "errors": {
+			const db = openReadonlyDb(root, "events.db");
+			if (!db) return jsonResponse([]);
+			try {
+				return jsonResponse(
+					db
+						.prepare("SELECT * FROM events WHERE level='error' ORDER BY created_at DESC LIMIT 50")
+						.all(),
+				);
+			} finally {
+				db.close();
+			}
+		}
+
+		case "metrics": {
+			const db = openReadonlyDb(root, "metrics.db");
+			if (!db) return jsonResponse([]);
+			try {
+				return jsonResponse(db.prepare("SELECT * FROM sessions ORDER BY started_at DESC").all());
+			} finally {
+				db.close();
+			}
+		}
+
+		case "groups":
+			return jsonResponse(await execOs(root, ["overstory", "group", "list", "--json"]));
+
+		case "runs":
+			return jsonResponse(await execOs(root, ["overstory", "run", "list", "--json"]));
+
+		case "terminal-start": {
+			try {
+				// Strip CLAUDECODE env var so claude CLI doesn't refuse to start
+				const cleanEnv: Record<string, string> = {};
+				for (const [key, value] of Object.entries(process.env)) {
+					if (key !== "CLAUDECODE" && key !== "CLAUDE_CODE_ENTRYPOINT" && value !== undefined) {
+						cleanEnv[key] = value;
+					}
+				}
+
+				// Ensure tmux server is running
+				const tmuxCheck = Bun.spawn(["tmux", "has-session"], {
+					stdout: "pipe",
+					stderr: "pipe",
+					env: cleanEnv,
+				});
+				const tmuxCheckCode = await tmuxCheck.exited;
+				if (tmuxCheckCode !== 0) {
+					const tmuxNew = Bun.spawn(["tmux", "new-session", "-d", "-s", "overstory-default"], {
+						stdout: "pipe",
+						stderr: "pipe",
+						env: cleanEnv,
+					});
+					await tmuxNew.exited;
+				}
+
+				// Start the coordinator
+				const coordProc = Bun.spawn(["overstory", "coordinator", "start", "--no-attach"], {
+					cwd: root,
+					stdout: "pipe",
+					stderr: "pipe",
+					env: cleanEnv,
+				});
+				await coordProc.exited;
+
+				const db = openReadonlyDb(root, "sessions.db");
+				let tmuxSession: string | null = null;
+				if (db) {
+					try {
+						const row = db
+							.prepare<{ tmux_session: string }, Record<string, never>>(
+								"SELECT tmux_session FROM sessions WHERE agent_name='orchestrator' AND state IN ('working','booting') ORDER BY started_at DESC LIMIT 1",
+							)
+							.get({});
+						tmuxSession = row?.tmux_session ?? null;
+					} finally {
+						db.close();
+					}
+				}
+
+				return jsonResponse({ ok: true, tmux_session: tmuxSession });
+			} catch (e: unknown) {
+				return jsonResponse({
+					error: e instanceof Error ? e.message : String(e),
+				});
+			}
+		}
+
+		case "usage": {
+			try {
+				const usageHelper = join(import.meta.dir, "../../dashboard/usage.ts");
+				const proc = Bun.spawn(["bun", usageHelper, root], {
+					cwd: root,
+					stdout: "pipe",
+					stderr: "pipe",
+				});
+				await proc.exited;
+				const raw = (await new Response(proc.stdout).text()).trim();
+				return jsonResponse(raw ? (JSON.parse(raw) as unknown) : { error: "empty" });
+			} catch (e: unknown) {
+				return jsonResponse({
+					error: e instanceof Error ? e.message : String(e),
+				});
+			}
+		}
+
+		default:
+			return new Response(JSON.stringify({ error: "Unknown endpoint" }), {
+				status: 404,
+				headers: { "Content-Type": "application/json" },
+			});
+	}
+}
+
+/**
+ * Serve static files from the dashboard/ directory.
+ */
+async function handleStatic(urlPath: string): Promise<Response> {
+	// dashboard/ dir is at ../../dashboard relative to src/commands/web.ts
+	const dashboardDir = join(import.meta.dir, "../../dashboard");
+
+	let filePath: string;
+	if (urlPath === "/" || urlPath === "/dashboard") {
+		filePath = join(dashboardDir, "index.html");
+	} else if (urlPath.startsWith("/dashboard/")) {
+		// Strip the leading /dashboard/ prefix to resolve inside dashboard dir
+		const relative = urlPath.slice("/dashboard/".length);
+		filePath = join(dashboardDir, relative);
+	} else {
+		// Other paths: serve directly relative to dashboard dir
+		filePath = join(dashboardDir, urlPath);
+	}
+
+	// Prevent path traversal: resolved path must stay within dashboard dir
+	const resolved = resolve(filePath);
+	const resolvedDashboard = resolve(dashboardDir);
+	if (!resolved.startsWith(`${resolvedDashboard}/`) && resolved !== resolvedDashboard) {
+		return new Response("Forbidden", { status: 403 });
+	}
+
+	const file = Bun.file(resolved);
+	const exists = await file.exists();
+	if (!exists) {
+		return new Response("Not found", { status: 404 });
+	}
+
+	const ext = filePath.slice(filePath.lastIndexOf("."));
+	const contentType = MIME[ext] ?? "application/octet-stream";
+
+	return new Response(file, {
+		headers: { "Content-Type": contentType },
+	});
+}
+
+// ── WebSocket terminal ──
+
+interface WsData {
+	sessionName: string;
+	proc?: ReturnType<typeof Bun.spawn>;
+	stdin?: { write(data: string | Uint8Array): number | Promise<number> } | null;
+	spawned?: boolean;
+}
+
+/**
+ * Spawn a PTY process for the given tmux session using script(1).
+ * Initial dimensions set via COLUMNS/LINES env vars + tmux resize-window.
+ */
+function spawnTerminal(
+	ws: { send: (d: string) => void; close: () => void; data: WsData },
+	sessionName: string,
+	cols: number,
+	rows: number,
+	cwd: string,
+): void {
+	// Validate dimensions
+	if (!Number.isFinite(rows) || !Number.isFinite(cols)) {
+		ws.send("[Error: invalid terminal dimensions]");
+		ws.close();
+		return;
+	}
+	const safeRows = Math.max(1, Math.min(Math.floor(rows), 500));
+	const safeCols = Math.max(1, Math.min(Math.floor(cols), 500));
+
+	// Validate session name
+	if (!/^[a-zA-Z0-9_\-.]+$/.test(sessionName)) {
+		ws.send("[Error: invalid session name]");
+		ws.close();
+		return;
+	}
+
+	// script -qfc allocates a real PTY. The -c flag requires a shell command
+	// string, so we can't use a pure array form. sessionName is validated
+	// above to match ^[a-zA-Z0-9_\-.]+$ and single-quoted, preventing injection.
+	// COLUMNS/LINES env vars set the initial size; we resize via tmux after attach.
+	const proc = Bun.spawn(
+		["script", "-qfc", `tmux attach-session -t '${sessionName}'`, "/dev/null"],
+		{
+			stdin: "pipe",
+			stdout: "pipe",
+			stderr: "pipe",
+			cwd,
+			env: {
+				...process.env,
+				TERM: "xterm-256color",
+				COLORTERM: "truecolor",
+				LANG: process.env.LANG ?? "C.UTF-8",
+				COLUMNS: String(safeCols),
+				LINES: String(safeRows),
+			},
+		},
+	);
+
+	ws.data.proc = proc;
+	ws.data.stdin = proc.stdin;
+	ws.data.spawned = true;
+
+	// Set terminal dimensions via tmux (array-based, no shell interpolation)
+	Bun.spawn(
+		["tmux", "resize-window", "-t", sessionName, "-x", String(safeCols), "-y", String(safeRows)],
+		{ stdout: "ignore", stderr: "ignore" },
+	);
+
+	// Stream stdout to WebSocket
+	const stdout = proc.stdout;
+	(async () => {
+		const reader = stdout.getReader();
+		try {
+			for (;;) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				try {
+					ws.send(new TextDecoder().decode(value));
+				} catch {
+					break;
+				}
+			}
+		} catch {
+			// Reader error — process likely exited
+		}
+		try {
+			ws.close();
+		} catch {
+			// Already closed
+		}
+	})();
+
+	proc.exited.then(() => {
+		try {
+			ws.close();
+		} catch {
+			// Already closed
+		}
+	});
+}
+
+/**
+ * Start a Bun.serve() instance with HTTP + native WebSocket support.
+ *
+ * Terminal WebSocket uses `script(1)` + `Bun.spawn` for PTY allocation instead
+ * of `node-pty`. This avoids a runtime dependency and works reliably inside
+ * Bun.serve()'s WebSocket handlers (node-pty's native addon event callbacks
+ * don't fire properly in Bun's event loop).
+ *
+ * The PTY spawn is deferred until the first resize message arrives from the
+ * client, so the terminal starts with the correct dimensions.
+ */
+export function startServer(port: number, root: string): ReturnType<typeof Bun.serve> {
+	const server = Bun.serve<WsData>({
+		port,
+
+		fetch(req, srv) {
+			const url = new URL(req.url);
+			let urlPath = url.pathname;
+
+			// Normalise trailing slash
+			if (urlPath.endsWith("/") && urlPath.length > 1) {
+				urlPath = urlPath.slice(0, -1);
+			}
+
+			// WebSocket upgrade: /ws/terminal/<session>
+			const wsMatch = urlPath.match(/^\/ws\/terminal\/(.+)$/);
+			if (wsMatch) {
+				const rawSession = wsMatch[1];
+				if (!rawSession) {
+					return new Response("Missing session name", { status: 400 });
+				}
+				const sessionName = safe(rawSession);
+				if (!sessionName) {
+					return new Response("Invalid session name", { status: 400 });
+				}
+				const upgraded = srv.upgrade(req, { data: { sessionName } });
+				if (!upgraded) {
+					return new Response("WebSocket upgrade failed", { status: 400 });
+				}
+				return undefined;
+			}
+
+			// Dashboard API
+			if (urlPath.startsWith("/dash/api/")) {
+				return handleDashApi(urlPath, req.url, root);
+			}
+
+			// Static files
+			return handleStatic(urlPath);
+		},
+
+		websocket: {
+			open(_ws) {
+				// PTY spawn is deferred to the first resize message so we
+				// know the actual terminal dimensions from the client.
+			},
+
+			message(ws, msg) {
+				const data = typeof msg === "string" ? msg : new TextDecoder().decode(msg);
+				const { sessionName } = ws.data;
+
+				// Parse JSON messages (resize)
+				try {
+					const parsed = JSON.parse(data) as unknown;
+					if (
+						parsed !== null &&
+						typeof parsed === "object" &&
+						"type" in parsed &&
+						"cols" in parsed &&
+						"rows" in parsed
+					) {
+						const obj = parsed as Record<string, unknown>;
+						if (
+							obj.type === "resize" &&
+							typeof obj.cols === "number" &&
+							typeof obj.rows === "number"
+						) {
+							const safeCols = Math.max(1, Math.min(Math.floor(obj.cols), 500));
+							const safeRows = Math.max(1, Math.min(Math.floor(obj.rows), 500));
+							if (!ws.data.spawned) {
+								// First resize: spawn the PTY with correct dimensions
+								try {
+									spawnTerminal(ws, sessionName, safeCols, safeRows, root);
+								} catch (e: unknown) {
+									const errMsg = e instanceof Error ? e.message : String(e);
+									try {
+										ws.send(`[Error starting terminal: ${errMsg}]`);
+									} catch {
+										// WebSocket may have closed
+									}
+									ws.close();
+								}
+							} else {
+								// Subsequent resize: update tmux window size
+								Bun.spawn(
+									[
+										"tmux",
+										"resize-window",
+										"-t",
+										sessionName,
+										"-x",
+										String(safeCols),
+										"-y",
+										String(safeRows),
+									],
+									{ stdout: "ignore", stderr: "ignore" },
+								);
+							}
+							return;
+						}
+					}
+				} catch {
+					// Not JSON — treat as raw input
+				}
+
+				// Forward raw input to PTY stdin
+				const { stdin } = ws.data;
+				if (stdin) {
+					stdin.write(data);
+				}
+			},
+
+			close(ws) {
+				const { proc } = ws.data;
+				if (proc) {
+					try {
+						proc.kill();
+					} catch {
+						// Already dead
+					}
+				}
+			},
+		},
+	});
+
+	return server;
+}
+
+const WEB_HELP = `overstory web — Start the Overstory web dashboard server
+
+Usage: overstory web [--port <port>] [--background] [--json]
+
+Options:
+  --port <port>      Port to listen on (default: 3000)
+  --background       Daemonize (run in background)
+  --json             Output JSON (port, pid, url)
+  --help, -h         Show this help`;
+
+/**
+ * Entry point for \`overstory web [--port <port>] [--background]\`.
+ */
+export async function webCommand(args: string[]): Promise<void> {
+	if (args.includes("--help") || args.includes("-h")) {
+		process.stdout.write(`${WEB_HELP}\n`);
+		return;
+	}
+
+	const portStr = getFlag(args, "--port");
+	const background = hasFlag(args, "--background");
+	const jsonOutput = hasFlag(args, "--json");
+
+	const cwd = process.cwd();
+	const config = await loadConfig(cwd);
+	const root = config.project.root;
+
+	const port = portStr ? Number.parseInt(portStr, 10) : 3000;
+	if (Number.isNaN(port) || port < 1 || port > 65535) {
+		process.stderr.write(
+			`Error: Invalid port '${portStr}'. Must be a number between 1 and 65535.\n`,
+		);
+		process.exitCode = 1;
+		return;
+	}
+
+	const pidFilePath = join(root, ".overstory", "web.pid");
+
+	if (background) {
+		// Check if the server is already running
+		const existingPid = await readPidFile(pidFilePath);
+		if (existingPid !== null && isProcessRunning(existingPid)) {
+			process.stderr.write(
+				`Error: Web server already running (PID: ${existingPid}). ` +
+					`Kill it first or remove ${pidFilePath}\n`,
+			);
+			process.exitCode = 1;
+			return;
+		}
+
+		// Clean up stale PID file if process is no longer running
+		if (existingPid !== null) {
+			await removePidFile(pidFilePath);
+		}
+
+		// Build child args forwarding --port but not --background
+		const childArgs: string[] = ["web"];
+		if (portStr) {
+			childArgs.push("--port", portStr);
+		}
+
+		// Resolve the overstory binary path
+		const overstoryBin = await resolveOverstoryBin();
+
+		// Spawn a detached background process running `overstory web` (without --background)
+		const child = Bun.spawn(["bun", "run", overstoryBin, ...childArgs], {
+			cwd,
+			stdout: "ignore",
+			stderr: "ignore",
+			stdin: "ignore",
+		});
+
+		// Unref the child so the parent can exit without waiting for it
+		child.unref();
+
+		const childPid = child.pid;
+
+		// Write PID file for later cleanup
+		await writePidFile(pidFilePath, childPid);
+
+		if (jsonOutput) {
+			process.stdout.write(
+				`${JSON.stringify({ port, pid: childPid, url: `http://localhost:${port}` })}\n`,
+			);
+		} else {
+			process.stdout.write(`Web server started in background (PID: ${childPid}, port: ${port})\n`);
+			process.stdout.write(`Dashboard: http://localhost:${port}\n`);
+			process.stdout.write(`PID file: ${pidFilePath}\n`);
+		}
+		return;
+	}
+
+	// Foreground mode
+	const server = startServer(port, root);
+
+	// Write PID file
+	await writePidFile(pidFilePath, process.pid);
+
+	if (jsonOutput) {
+		process.stdout.write(
+			`${JSON.stringify({ port, pid: process.pid, url: `http://localhost:${port}` })}\n`,
+		);
+	} else {
+		process.stdout.write(`Overstory Dashboard: http://localhost:${port}\n`);
+		process.stdout.write("Press Ctrl+C to stop.\n");
+	}
+
+	// SIGINT cleanup
+	process.on("SIGINT", () => {
+		server.stop();
+		removePidFile(pidFilePath).finally(() => {
+			process.stdout.write("\nWeb server stopped.\n");
+			process.exit(0);
+		});
+	});
+
+	// Block forever
+	await new Promise(() => {});
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import { statusCommand } from "./commands/status.ts";
 import { supervisorCommand } from "./commands/supervisor.ts";
 import { traceCommand } from "./commands/trace.ts";
 import { watchCommand } from "./commands/watch.ts";
+import { webCommand } from "./commands/web.ts";
 import { worktreeCommand } from "./commands/worktree.ts";
 import { OverstoryError, WorktreeError } from "./errors.ts";
 import { setQuiet } from "./logging/color.ts";
@@ -69,6 +70,7 @@ Commands:
   log <event>             Log a hook event
   logs [options]          Query NDJSON logs across agents
   watch                   Start watchdog daemon
+  web                     Start web dashboard server
   feed [options]          Unified real-time event stream across all agents
   trace <target>         Chronological event timeline for agent/bead
   errors [options]        Aggregated error view across agents
@@ -108,6 +110,7 @@ const COMMANDS = [
 	"log",
 	"logs",
 	"watch",
+	"web",
 	"trace",
 	"feed",
 	"errors",
@@ -254,6 +257,9 @@ async function main(): Promise<void> {
 			break;
 		case "watch":
 			await watchCommand(commandArgs);
+			break;
+		case "web":
+			await webCommand(commandArgs);
 			break;
 		case "trace":
 			await traceCommand(commandArgs);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
 			"@/*": ["./src/*"]
 		}
 	},
-	"include": ["src/**/*.ts"]
+	"include": ["src/**/*.ts", "dashboard/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

Adds `overstory web` command — a self-contained browser-based dashboard for monitoring and controlling agent swarms. Just run `overstory web` and open the URL — you can start the orchestrator, monitor agents, and interact with terminals all from the browser.

Built with Bun.serve() (HTTP + native WebSocket), serving a Catppuccin-themed SPA with real-time polling.

- **Self-contained**: start the orchestrator directly from the dashboard — no need to set up tmux sessions manually
- **Agent sidebar**: live agent tree with status indicators, click to inspect
- **Interactive terminal**: xterm.js connected to tmux sessions via WebSocket + script(1) PTY
- **Observability panels**: mail, merge queue, events, metrics, errors, trace timeline
- **Usage tracking**: token/cost analysis from Claude Code transcripts

### Technical decisions

- **Zero runtime dependencies** preserved — this is the key constraint shaping the terminal implementation. `node-pty` would provide a significantly better terminal experience (dynamic resize, proper PTY control) but would break the zero-dep rule. Instead, `script(1)` + `Bun.spawn` is used for PTY allocation, which works reliably inside Bun.serve()'s WebSocket handlers where node-pty's native addon event callbacks don't fire anyway.
- **Deferred PTY spawn** — terminal waits for the first resize message from xterm.js before spawning, so the PTY starts with correct dimensions matching the browser window.
- **Known limitation**: terminal does not dynamically resize after initial connection. `script(1)` allocates a fixed-size PTY that can't be resized post-spawn. Adding `node-pty` as a runtime dependency would solve this if the zero-dep policy is relaxed in the future.

### Files added
| File | Description |
|---|---|
| `src/commands/web.ts` | Bun.serve() HTTP + WebSocket server (~640 lines) |
| `src/commands/web.test.ts` | Tests (help, invalid port, PID lifecycle) |
| `dashboard/index.html` | Dashboard HTML |
| `dashboard/dashboard.js` | Frontend JS (polling, xterm.js, rendering) |
| `dashboard/dashboard.css` | Catppuccin Mocha theme styles |
| `dashboard/query.ts` | SQLite query helper (spawned by server) |
| `dashboard/usage.ts` | Usage/cost scanner (Claude Code transcripts) |

### Files modified
| File | Change |
|---|---|
| `src/index.ts` | Register `web` command |
| `src/commands/completions.ts` | Add `web` to shell completions |
| `src/commands/completions.test.ts` | Update command count assertion |
| `package.json` | No new dependencies |

## Test plan
- [x] `bun test` — all tests pass (including 7 new web command tests)
- [x] `bunx biome check .` — clean
- [x] `bunx tsc --noEmit` — clean
- [ ] Manual: `overstory web --port 4000` in an initialized project
- [ ] Manual: verify agent sidebar, terminal, mail, metrics panels
- [ ] Manual: verify Start Orchestrator button launches orchestrator from dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)