### PR TITLE
feat: capabilities refactoring + tracker migration + canopy integration

### DIFF
--- a/.overstory/agent-manifest.json
+++ b/.overstory/agent-manifest.json
@@ -17,6 +17,10 @@
 			"canSpawn": false,
 			"constraints": [
 				"read-only"
+			],
+			"tags": [
+				"exploration",
+				"research"
 			]
 		},
 		"builder": {
@@ -36,7 +40,10 @@
 				"fix"
 			],
 			"canSpawn": false,
-			"constraints": []
+			"constraints": [],
+			"tags": [
+				"implementation"
+			]
 		},
 		"reviewer": {
 			"file": "reviewer.md",
@@ -54,6 +61,10 @@
 			"canSpawn": false,
 			"constraints": [
 				"read-only"
+			],
+			"tags": [
+				"code-quality",
+				"validation"
 			]
 		},
 		"lead": {
@@ -74,7 +85,11 @@
 				"review"
 			],
 			"canSpawn": true,
-			"constraints": []
+			"constraints": [],
+			"tags": [
+				"coordination",
+				"planning"
+			]
 		},
 		"merger": {
 			"file": "merger.md",
@@ -92,7 +107,11 @@
 				"resolve-conflicts"
 			],
 			"canSpawn": false,
-			"constraints": []
+			"constraints": [],
+			"tags": [
+				"merge",
+				"conflict-resolution"
+			]
 		},
 		"coordinator": {
 			"file": "coordinator.md",
@@ -112,6 +131,10 @@
 			"constraints": [
 				"read-only",
 				"no-worktree"
+			],
+			"tags": [
+				"dispatch",
+				"orchestration"
 			]
 		},
 		"supervisor": {
@@ -131,7 +154,11 @@
 				"supervise"
 			],
 			"canSpawn": true,
-			"constraints": []
+			"constraints": [],
+			"tags": [
+				"supervision",
+				"coordination"
+			]
 		},
 		"monitor": {
 			"file": "monitor.md",
@@ -150,6 +177,10 @@
 			"constraints": [
 				"read-only",
 				"no-worktree"
+			],
+			"tags": [
+				"monitoring",
+				"patrol"
 			]
 		}
 	},
@@ -198,6 +229,51 @@
 			"supervisor"
 		],
 		"monitor": [
+			"monitor"
+		],
+		"patrol": [
+			"monitor"
+		]
+	},
+	"tagIndex": {
+		"exploration": [
+			"scout"
+		],
+		"research": [
+			"scout"
+		],
+		"implementation": [
+			"builder"
+		],
+		"code-quality": [
+			"reviewer"
+		],
+		"validation": [
+			"reviewer"
+		],
+		"coordination": [
+			"lead",
+			"supervisor"
+		],
+		"planning": [
+			"lead"
+		],
+		"merge": [
+			"merger"
+		],
+		"conflict-resolution": [
+			"merger"
+		],
+		"dispatch": [
+			"coordinator"
+		],
+		"orchestration": [
+			"coordinator"
+		],
+		"supervision": [
+			"supervisor"
+		],
+		"monitoring": [
 			"monitor"
 		],
 		"patrol": [

--- a/.overstory/config.yaml
+++ b/.overstory/config.yaml
@@ -3,7 +3,7 @@
 
 project:
   name: overstory
-  root: /Users/jayminwest/Projects/overstory
+  root: /home/n0ko/Programs/ai/overstory
   canonicalBranch: main
 agents:
   manifestPath: .overstory/agent-manifest.json

--- a/agents/builder.md
+++ b/agents/builder.md
@@ -74,7 +74,25 @@ Your task-specific context (task ID, file scope, spec path, branch name, parent 
 
 You are a **builder agent** in the overstory swarm system. Your job is to implement changes according to a spec. You write code, run tests, and deliver working software.
 
-## role
+## Philosophy
+
+- Do one thing well: implement the spec.
+- KISS: simple code that passes quality gates. No gold-plating.
+- DRY: extract shared logic, never copy-paste across files.
+- YAGNI: build what the spec asks, nothing more.
+- Comments explain "why" not "what" -- code should be self-documenting.
+
+## One Word Output
+
+Respond with only "Done."
+
+Exceptions:
+1. Explicitly asked to respond with something other than "Done." -- respond with what was requested.
+2. Explicitly asked a question -- answer in 1 sentence max.
+3. Error, blocker, or failure -- explain in 1 sentence max.
+4. Reporting completion via mail -- results are your deliverable.
+
+## Role
 
 You are an implementation specialist. Given a spec and a set of files you own, you build the thing. You write clean, tested code that passes quality gates. You work within your file scope and commit to your worktree branch only.
 

--- a/agents/coordinator.md
+++ b/agents/coordinator.md
@@ -74,7 +74,26 @@ This file tells you HOW to coordinate. Your objectives come from the channels ab
 
 You are the **coordinator agent** in the overstory swarm system. You are the persistent orchestrator brain -- the strategic center that decomposes high-level objectives into lead assignments, monitors lead progress, handles escalations, and merges completed work. You do not implement code or write specs. You think, decompose at a high level, dispatch leads, and monitor.
 
-## role
+## Philosophy
+
+- Do one thing well: strategic decomposition and lead dispatch.
+- Composition over inheritance: compose leads, do not micromanage their workers.
+- KISS: right-size the lead count. Each lead costs a session plus its workers.
+- YAGNI: dispatch the minimum leads needed. You can always add more later.
+- Comments explain "why" not "what" -- dispatch mails should explain WHY a lead was assigned this scope.
+
+## One Word Output
+
+Respond with only "Done."
+
+Exceptions:
+1. Explicitly asked to respond with something other than "Done." -- respond with what was requested.
+2. Explicitly asked a question -- answer in 1 sentence max.
+3. Error, blocker, or failure -- explain in 1 sentence max.
+4. Reporting to the human operator -- summaries are your deliverable.
+5. Dispatch mails to leads -- these require full context.
+
+## Role
 
 You are the top-level decision-maker for automated work. When a human gives you an objective (a feature, a refactor, a migration), you analyze it, create high-level {{TRACKER_NAME}} issues, dispatch **lead agents** to own each work stream, monitor their progress via mail and status checks, and handle escalations. Leads handle all downstream coordination: they spawn scouts to explore, write specs from findings, spawn builders to implement, and spawn reviewers to validate. You operate from the project root with full read visibility but **no write access** to any files. Your outputs are issues, lead dispatches, and coordination messages -- never code, never specs.
 

--- a/agents/lead.md
+++ b/agents/lead.md
@@ -60,7 +60,24 @@ Your task-specific context (task ID, spec path, hierarchy depth, agent name, whe
 
 You are a **team lead agent** in the overstory swarm system. Your job is to decompose work, delegate to specialists, and verify results. You coordinate a team of scouts, builders, and reviewers — you do not do their work yourself.
 
-## role
+## Philosophy
+
+- Do one thing well: decompose, delegate, verify.
+- Composition over inheritance: compose specialists, do not try to be all of them.
+- KISS: minimum viable decomposition. Fewer well-scoped workers beat many narrow ones.
+- YAGNI: do not spawn workers for work you can do yourself in fewer tool calls.
+
+## One Word Output
+
+Respond with only "Done."
+
+Exceptions:
+1. Explicitly asked to respond with something other than "Done." -- respond with what was requested.
+2. Explicitly asked a question -- answer in 1 sentence max.
+3. Error, blocker, or failure -- explain in 1 sentence max.
+4. Reporting status/completion via mail -- coordination signals are your deliverable.
+
+## Role
 
 You are primarily a coordinator, but you can also be a doer for simple tasks. Your primary value is decomposition, delegation, and verification — deciding what work to do, who should do it, and whether it was done correctly. For simple tasks, you do the work directly. For moderate and complex tasks, you delegate through the Scout → Build → Verify pipeline.
 

--- a/agents/merger.md
+++ b/agents/merger.md
@@ -66,7 +66,23 @@ Your task-specific context (task ID, branches to merge, target branch, merge ord
 
 You are a **merger agent** in the overstory swarm system. Your job is to integrate branches from completed worker agents back into the target branch, resolving conflicts through a tiered escalation process.
 
-## role
+## Philosophy
+
+- Do one thing well: merge branches cleanly.
+- KISS: always start at Tier 1 (clean merge). Escalate only on failure.
+- Comments explain "why" not "what" -- merge commits should explain WHY conflicts arose, not just WHAT was resolved.
+
+## One Word Output
+
+Respond with only "Done."
+
+Exceptions:
+1. Explicitly asked to respond with something other than "Done." -- respond with what was requested.
+2. Explicitly asked a question -- answer in 1 sentence max.
+3. Error, blocker, or failure -- explain in 1 sentence max.
+4. Reporting merge results via mail -- results are your deliverable.
+
+## Role
 
 You are a branch integration specialist. When workers complete their tasks on separate branches, you merge their changes cleanly into the target branch. When conflicts arise, you escalate through resolution tiers: clean merge, auto-resolve, AI-resolve, and reimagine. You preserve commit history and ensure the merged result is correct.
 

--- a/agents/monitor.md
+++ b/agents/monitor.md
@@ -39,7 +39,24 @@ This file tells you HOW to monitor. Your patrol loop discovers WHAT needs attent
 
 You are the **monitor agent** (Tier 2) in the overstory swarm system. You are a continuous patrol agent -- a long-running sentinel that monitors all active supervisors and workers, detects anomalies, handles lifecycle requests, and provides health summaries to the orchestrator. You do not implement code. You observe, analyze, intervene, and report.
 
-## role
+## Philosophy
+
+- Do one thing well: observe the fleet and report anomalies.
+- KISS: batch status checks, adaptive cadence, concise reports.
+- Comments explain "why" not "what" -- health summaries should explain WHY an agent is concerning, not just WHAT its state is.
+
+## One Word Output
+
+Respond with only "Done."
+
+Exceptions:
+1. Explicitly asked to respond with something other than "Done." -- respond with what was requested.
+2. Explicitly asked a question -- answer in 1 sentence max.
+3. Error, blocker, or failure -- explain in 1 sentence max.
+4. Health summaries to coordinator -- these are your deliverable.
+5. Escalation mails -- these require full context.
+
+## Role
 
 You are the watchdog's brain. While Tier 0 (mechanical daemon) checks tmux/pid liveness on a heartbeat, and Tier 1 (ephemeral triage) makes one-shot AI classifications, you maintain continuous awareness of the entire agent fleet. You track patterns over time -- which agents are repeatedly stalling, which tasks are taking longer than expected, which branches have gone quiet. You send nudges, request restarts, escalate to the coordinator, and produce periodic health summaries.
 

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -64,7 +64,23 @@ The only write exception is `overstory spec write` for persisting spec files (sc
 
 You are a **reviewer agent** in the overstory swarm system. Your job is to validate code changes, run quality checks, and report results. You are strictly read-only -- you observe and report but never modify.
 
-## role
+## Philosophy
+
+- Do one thing well: validate and report.
+- KISS: PASS or FAIL with actionable feedback. No essays.
+- Comments explain "why" not "what" -- feedback should explain WHY something is wrong, not just WHAT is wrong.
+
+## One Word Output
+
+Respond with only "Done."
+
+Exceptions:
+1. Explicitly asked to respond with something other than "Done." -- respond with what was requested.
+2. Explicitly asked a question -- answer in 1 sentence max.
+3. Error, blocker, or failure -- explain in 1 sentence max.
+4. Reporting review results via mail -- reviews are your deliverable.
+
+## Role
 
 You are a validation specialist. Given code to review, you check it for correctness, style, security issues, test coverage, and adherence to project conventions. You run tests and linters to get objective results. You report pass/fail with actionable feedback.
 

--- a/agents/scout.md
+++ b/agents/scout.md
@@ -64,7 +64,24 @@ The only write exception is `overstory spec write` for persisting spec files (sc
 
 You are a **scout agent** in the overstory swarm system. Your job is to explore codebases, gather information, and report findings. You are strictly read-only -- you never modify anything.
 
-## role
+## Philosophy
+
+- Do one thing well: explore and report.
+- Composition over inheritance: your findings feed specs that feed builders.
+- KISS: report what matters, skip what does not.
+- Comments explain "why" not "what" -- your findings should explain WHY something exists, not just WHAT it is.
+
+## One Word Output
+
+Respond with only "Done."
+
+Exceptions:
+1. Explicitly asked to respond with something other than "Done." -- respond with what was requested.
+2. Explicitly asked a question -- answer in 1 sentence max.
+3. Error, blocker, or failure -- explain in 1 sentence max.
+4. Reporting findings via mail -- findings are your deliverable.
+
+## Role
 
 You perform reconnaissance. Given a research question, exploration target, or analysis task, you systematically investigate the codebase and report what you find. You are the eyes of the swarm -- fast, thorough, and non-destructive.
 

--- a/agents/supervisor.md
+++ b/agents/supervisor.md
@@ -75,7 +75,26 @@ This file tells you HOW to supervise. Your overlay tells you WHAT to supervise.
 
 You are the **supervisor agent** in the overstory swarm system. You are a persistent per-project team lead that manages batches of worker agents -- receiving high-level tasks from the coordinator, decomposing them into worker-sized subtasks, spawning and monitoring workers, handling the worker-done → merge-ready lifecycle, and escalating unresolvable issues upstream. You do not implement code. You coordinate, delegate, verify, and report.
 
-## role
+## Philosophy
+
+- Do one thing well: decompose, spawn, monitor, verify.
+- Composition over inheritance: compose workers with non-overlapping file scope.
+- KISS: minimum viable decomposition. Prefer 2-4 workers over 8-10.
+- YAGNI: do not over-decompose. You can always spawn more workers later.
+- Comments explain "why" not "what" -- specs should explain WHY a worker gets this scope.
+
+## One Word Output
+
+Respond with only "Done."
+
+Exceptions:
+1. Explicitly asked to respond with something other than "Done." -- respond with what was requested.
+2. Explicitly asked a question -- answer in 1 sentence max.
+3. Error, blocker, or failure -- explain in 1 sentence max.
+4. Reporting to coordinator -- status and results are your deliverable.
+5. Assign/dispatch mails to workers -- these require full context.
+
+## Role
 
 You are the coordinator's field lieutenant. When the coordinator assigns you a project-level task (a feature module, a subsystem refactor, a test suite), you analyze it, break it into leaf-worker subtasks, spawn builders/scouts/reviewers at depth 2, monitor their completion via mail and status checks, verify their work, signal merge readiness to the coordinator, and handle failures and escalations. You operate from the project root with full read visibility but no write access to source files. Your outputs are subtasks, specs, worker spawns, merge-ready signals, and escalations -- never code.
 

--- a/src/agents/manifest.test.ts
+++ b/src/agents/manifest.test.ts
@@ -4,7 +4,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { AgentError } from "../errors.ts";
 import type { AgentManifest, OverstoryConfig } from "../types.ts";
-import { createManifestLoader, resolveModel, resolveProviderEnv } from "./manifest.ts";
+import {
+	createManifestLoader,
+	parseAgentFrontmatter,
+	resolveModel,
+	resolveProviderEnv,
+	resolveUserAgent,
+} from "./manifest.ts";
 
 const VALID_MANIFEST = {
 	version: "1.0",
@@ -209,6 +215,168 @@ describe("createManifestLoader", () => {
 
 			const reviewers = loader.findByCapability("review");
 			expect(reviewers).toHaveLength(2);
+		});
+	});
+
+	describe("findByTag", () => {
+		test("returns empty array before load is called", async () => {
+			await writeManifest(VALID_MANIFEST);
+			const loader = createManifestLoader(manifestPath, agentBaseDir);
+
+			expect(loader.findByTag("security")).toEqual([]);
+		});
+
+		test("returns matching agents by tag after load", async () => {
+			const data = {
+				version: "1.0",
+				agents: {
+					scout: {
+						file: "scout.md",
+						model: "sonnet",
+						tools: ["Read"],
+						capabilities: ["explore"],
+						canSpawn: false,
+						constraints: [],
+						tags: ["security", "exploration"],
+					},
+					builder: {
+						file: "builder.md",
+						model: "sonnet",
+						tools: ["Read", "Write"],
+						capabilities: ["implement"],
+						canSpawn: false,
+						constraints: [],
+						tags: ["unix-coder"],
+					},
+				},
+			};
+			await writeManifest(data);
+			const loader = createManifestLoader(manifestPath, agentBaseDir);
+			await loader.load();
+
+			const securityAgents = loader.findByTag("security");
+			expect(securityAgents).toHaveLength(1);
+			expect(securityAgents[0]?.file).toBe("scout.md");
+
+			const coderAgents = loader.findByTag("unix-coder");
+			expect(coderAgents).toHaveLength(1);
+			expect(coderAgents[0]?.file).toBe("builder.md");
+		});
+
+		test("returns empty array for non-existent tag", async () => {
+			await writeManifest(VALID_MANIFEST);
+			const loader = createManifestLoader(manifestPath, agentBaseDir);
+			await loader.load();
+
+			expect(loader.findByTag("nonexistent")).toEqual([]);
+		});
+
+		test("returns multiple agents sharing a tag", async () => {
+			const data = {
+				version: "1.0",
+				agents: {
+					scout: {
+						file: "scout.md",
+						model: "sonnet",
+						tools: ["Read"],
+						capabilities: ["explore"],
+						canSpawn: false,
+						constraints: [],
+						tags: ["code-quality"],
+					},
+					reviewer: {
+						file: "reviewer.md",
+						model: "sonnet",
+						tools: ["Read"],
+						capabilities: ["review"],
+						canSpawn: false,
+						constraints: [],
+						tags: ["code-quality"],
+					},
+				},
+			};
+			await writeManifest(data);
+			const loader = createManifestLoader(manifestPath, agentBaseDir);
+			await loader.load();
+
+			const cqAgents = loader.findByTag("code-quality");
+			expect(cqAgents).toHaveLength(2);
+		});
+
+		test("agents without tags are not indexed", async () => {
+			const data = {
+				version: "1.0",
+				agents: {
+					scout: {
+						file: "scout.md",
+						model: "sonnet",
+						tools: ["Read"],
+						capabilities: ["explore"],
+						canSpawn: false,
+						constraints: [],
+						// No tags
+					},
+				},
+			};
+			await writeManifest(data);
+			const loader = createManifestLoader(manifestPath, agentBaseDir);
+			const manifest = await loader.load();
+
+			expect(manifest.tagIndex).toEqual({});
+		});
+	});
+
+	describe("tag validation", () => {
+		test("accepts agents without tags", async () => {
+			await writeManifest(VALID_MANIFEST);
+			const loader = createManifestLoader(manifestPath, agentBaseDir);
+			const manifest = await loader.load();
+
+			expect(manifest.agents.scout).toBeDefined();
+		});
+
+		test("accepts agents with valid tags array", async () => {
+			const data = {
+				version: "1.0",
+				agents: {
+					scout: {
+						file: "scout.md",
+						model: "sonnet",
+						tools: ["Read"],
+						capabilities: ["explore"],
+						canSpawn: false,
+						constraints: [],
+						tags: ["security", "code-quality"],
+					},
+				},
+			};
+			await writeManifest(data);
+			const loader = createManifestLoader(manifestPath, agentBaseDir);
+			const manifest = await loader.load();
+
+			expect(manifest.agents.scout?.tags).toEqual(["security", "code-quality"]);
+		});
+
+		test("throws when tags is not an array", async () => {
+			const data = {
+				version: "1.0",
+				agents: {
+					bad: {
+						file: "bad.md",
+						model: "sonnet",
+						tools: ["Read"],
+						capabilities: ["test"],
+						canSpawn: false,
+						constraints: [],
+						tags: "not-an-array",
+					},
+				},
+			};
+			await writeManifest(data);
+			const loader = createManifestLoader(manifestPath, agentBaseDir);
+
+			await expect(loader.load()).rejects.toThrow(AgentError);
+			await expect(loader.load()).rejects.toThrow("tags");
 		});
 	});
 
@@ -522,6 +690,8 @@ describe("resolveModel", () => {
 				staggerDelayMs: 1000,
 				maxDepth: 2,
 				maxSessionsPerRun: 0,
+				userAgentDir: "",
+				capabilityAliases: {},
 			},
 			worktrees: { baseDir: ".overstory/worktrees" },
 			taskTracker: { backend: "auto", enabled: false },
@@ -539,6 +709,11 @@ describe("resolveModel", () => {
 			},
 			models,
 			logging: { verbose: false, redactSecrets: true },
+			slashCommands: [],
+			tracking: {
+				provider: "builtin" as const,
+				externalAgents: { trackManager: "", dependencyManager: "" },
+			},
 		};
 	}
 
@@ -742,5 +917,121 @@ describe("manifest validation accepts arbitrary model strings", () => {
 
 		const manifest = await loader.load();
 		expect(manifest.agents.agent?.model).toBe("openrouter/openai/gpt-5.3");
+	});
+});
+
+describe("parseAgentFrontmatter", () => {
+	test("parses standard YAML frontmatter", () => {
+		const content = `---
+name: unix-coder
+description: "A coding agent"
+model: sonnet
+color: red
+---
+
+You are an expert programmer.`;
+
+		const { frontmatter, body } = parseAgentFrontmatter(content);
+
+		expect(frontmatter.name).toBe("unix-coder");
+		expect(frontmatter.description).toBe("A coding agent");
+		expect(frontmatter.model).toBe("sonnet");
+		expect(frontmatter.color).toBe("red");
+		expect(body).toContain("You are an expert programmer.");
+	});
+
+	test("returns empty frontmatter for content without frontmatter", () => {
+		const content = "# Just a heading\n\nSome content.";
+
+		const { frontmatter, body } = parseAgentFrontmatter(content);
+
+		expect(frontmatter).toEqual({});
+		expect(body).toBe(content);
+	});
+
+	test("returns empty frontmatter for content with unclosed frontmatter", () => {
+		const content = "---\nname: test\nSome content without a closing delimiter";
+
+		const { frontmatter, body } = parseAgentFrontmatter(content);
+
+		expect(frontmatter).toEqual({});
+		expect(body).toBe(content);
+	});
+
+	test("handles single-quoted values", () => {
+		const content = `---
+name: 'unix-coder'
+---
+
+Content.`;
+
+		const { frontmatter } = parseAgentFrontmatter(content);
+		expect(frontmatter.name).toBe("unix-coder");
+	});
+
+	test("handles double-quoted values", () => {
+		const content = `---
+name: "unix-coder"
+---
+
+Content.`;
+
+		const { frontmatter } = parseAgentFrontmatter(content);
+		expect(frontmatter.name).toBe("unix-coder");
+	});
+
+	test("handles unquoted values", () => {
+		const content = `---
+model: opus
+---
+
+Content.`;
+
+		const { frontmatter } = parseAgentFrontmatter(content);
+		expect(frontmatter.model).toBe("opus");
+	});
+});
+
+describe("resolveUserAgent", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "overstory-user-agent-test-"));
+		await mkdir(join(tempDir, ".lazy"), { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	test("resolves agent from direct directory", async () => {
+		await Bun.write(join(tempDir, "unix-coder.md"), "# Unix Coder\n");
+
+		const content = await resolveUserAgent(tempDir, "unix-coder.md");
+
+		expect(content).toBe("# Unix Coder\n");
+	});
+
+	test("resolves agent from .lazy/ subdirectory", async () => {
+		await Bun.write(join(tempDir, ".lazy", "code-review.md"), "# Code Review\n");
+
+		const content = await resolveUserAgent(tempDir, "code-review.md");
+
+		expect(content).toBe("# Code Review\n");
+	});
+
+	test("prefers direct directory over .lazy/", async () => {
+		await Bun.write(join(tempDir, "agent.md"), "# Direct\n");
+		await Bun.write(join(tempDir, ".lazy", "agent.md"), "# Lazy\n");
+
+		const content = await resolveUserAgent(tempDir, "agent.md");
+
+		expect(content).toBe("# Direct\n");
+	});
+
+	test("returns null for non-existent agent", async () => {
+		const content = await resolveUserAgent(tempDir, "nonexistent.md");
+
+		expect(content).toBeNull();
 	});
 });

--- a/src/agents/manifest.ts
+++ b/src/agents/manifest.ts
@@ -18,6 +18,8 @@ export interface ManifestLoader {
 	getAgent(name: string): AgentDefinition | undefined;
 	/** Find all agent names whose capabilities include the given capability. */
 	findByCapability(capability: string): AgentDefinition[];
+	/** Find all agent definitions whose tags include the given tag. */
+	findByTag(tag: string): AgentDefinition[];
 	/** Validate the manifest. Returns a list of errors (empty = valid). */
 	validate(): string[];
 }
@@ -90,6 +92,19 @@ function validateAgentDefinition(name: string, raw: unknown): string[] {
 		}
 	}
 
+	// Tags are optional — validate only if present
+	if (def.tags !== undefined) {
+		if (!Array.isArray(def.tags)) {
+			errors.push(`Agent "${name}": "tags" must be an array if present`);
+		} else {
+			for (let i = 0; i < def.tags.length; i++) {
+				if (typeof def.tags[i] !== "string") {
+					errors.push(`Agent "${name}": "tags[${i}]" must be a string`);
+				}
+			}
+		}
+	}
+
 	return errors;
 }
 
@@ -107,6 +122,28 @@ function buildCapabilityIndex(agents: Record<string, AgentDefinition>): Record<s
 				existing.push(name);
 			} else {
 				index[cap] = [name];
+			}
+		}
+	}
+
+	return index;
+}
+
+/**
+ * Build a tag index: maps each tag string to the list of
+ * agent names that declare that tag.
+ */
+function buildTagIndex(agents: Record<string, AgentDefinition>): Record<string, string[]> {
+	const index: Record<string, string[]> = {};
+
+	for (const [name, def] of Object.entries(agents)) {
+		if (!def.tags) continue;
+		for (const tag of def.tags) {
+			const existing = index[tag];
+			if (existing) {
+				existing.push(name);
+			} else {
+				index[tag] = [name];
 			}
 		}
 	}
@@ -194,13 +231,15 @@ export function createManifestLoader(manifestPath: string, agentBaseDir: string)
 				}
 			}
 
-			// Build the capability index
+			// Build indexes
 			const capabilityIndex = buildCapabilityIndex(agents);
+			const tagIndex = buildTagIndex(agents);
 
 			manifest = {
 				version: raw.version,
 				agents,
 				capabilityIndex,
+				tagIndex,
 			};
 
 			return manifest;
@@ -219,6 +258,26 @@ export function createManifestLoader(manifestPath: string, agentBaseDir: string)
 			}
 
 			const agentNames = manifest.capabilityIndex[capability];
+			if (!agentNames) {
+				return [];
+			}
+
+			const results: AgentDefinition[] = [];
+			for (const name of agentNames) {
+				const def = manifest.agents[name];
+				if (def) {
+					results.push(def);
+				}
+			}
+			return results;
+		},
+
+		findByTag(tag: string): AgentDefinition[] {
+			if (!manifest) {
+				return [];
+			}
+
+			const agentNames = manifest.tagIndex?.[tag];
 			if (!agentNames) {
 				return [];
 			}
@@ -277,6 +336,118 @@ export function createManifestLoader(manifestPath: string, agentBaseDir: string)
 			return errors;
 		},
 	};
+}
+
+// === User Agent Resolution ===
+
+/** Parsed frontmatter from a user agent definition file (.md with YAML header). */
+export interface UserAgentFrontmatter {
+	name?: string;
+	description?: string;
+	model?: string;
+	color?: string;
+	tags?: string[];
+}
+
+/**
+ * Parse YAML frontmatter from a user agent definition file.
+ *
+ * User agent files use the format:
+ * ```
+ * ---
+ * name: unix-coder
+ * description: "..."
+ * model: sonnet
+ * color: red
+ * ---
+ * (agent prompt content)
+ * ```
+ *
+ * Returns the parsed frontmatter fields and the body content separately.
+ */
+export function parseAgentFrontmatter(content: string): {
+	frontmatter: UserAgentFrontmatter;
+	body: string;
+} {
+	const trimmed = content.trimStart();
+	if (!trimmed.startsWith("---")) {
+		return { frontmatter: {}, body: content };
+	}
+
+	const endIdx = trimmed.indexOf("---", 3);
+	if (endIdx === -1) {
+		return { frontmatter: {}, body: content };
+	}
+
+	const fmBlock = trimmed.substring(3, endIdx).trim();
+	const body = trimmed.substring(endIdx + 3).trimStart();
+
+	const frontmatter: UserAgentFrontmatter = {};
+
+	for (const line of fmBlock.split("\n")) {
+		const colonIdx = line.indexOf(":");
+		if (colonIdx === -1) continue;
+
+		const key = line.substring(0, colonIdx).trim();
+		let value = line.substring(colonIdx + 1).trim();
+
+		// Strip surrounding quotes
+		if (
+			(value.startsWith('"') && value.endsWith('"')) ||
+			(value.startsWith("'") && value.endsWith("'"))
+		) {
+			value = value.slice(1, -1);
+		}
+
+		switch (key) {
+			case "name":
+				frontmatter.name = value;
+				break;
+			case "model":
+				frontmatter.model = value;
+				break;
+			case "color":
+				frontmatter.color = value;
+				break;
+			case "description":
+				frontmatter.description = value;
+				break;
+		}
+	}
+
+	return { frontmatter, body };
+}
+
+/**
+ * Resolve a user agent file for a capability alias.
+ *
+ * Searches the user agent directory (and its .lazy/ subdirectory) for
+ * the specified agent file. Returns the full file content if found,
+ * or null if not found.
+ *
+ * @param userAgentDir - Absolute path to the user agent directory (e.g., ~/.claude/agents)
+ * @param agentFileName - The agent filename to look for (e.g., "unix-coder.md")
+ * @returns The file content if found, or null
+ */
+export async function resolveUserAgent(
+	userAgentDir: string,
+	agentFileName: string,
+): Promise<string | null> {
+	// Check directly in the user agent directory
+	const directPath = join(userAgentDir, agentFileName);
+	const directFile = Bun.file(directPath);
+	if (await directFile.exists()) {
+		return directFile.text();
+	}
+
+	// Check in the .lazy/ subdirectory (Claude Code lazy-loaded agents)
+	const lazyPath = join(userAgentDir, ".lazy", agentFileName);
+	const lazyFile = Bun.file(lazyPath);
+	if (await lazyFile.exists()) {
+		return lazyFile.text();
+	}
+
+	return null;
 }
 
 const DEFAULT_GATEWAY_ALIAS = "sonnet";

--- a/src/agents/overlay.test.ts
+++ b/src/agents/overlay.test.ts
@@ -651,6 +651,115 @@ describe("writeOverlay", () => {
 	});
 });
 
+describe("slash commands rendering", () => {
+	test("omits slash commands section when none configured", async () => {
+		const config = makeConfig({ slashCommands: undefined });
+		const output = await generateOverlay(config);
+		expect(output).not.toContain("Available Slash Commands");
+	});
+
+	test("omits slash commands section when empty array", async () => {
+		const config = makeConfig({ slashCommands: [] });
+		const output = await generateOverlay(config);
+		expect(output).not.toContain("Available Slash Commands");
+	});
+
+	test("omits slash commands section when none match capability", async () => {
+		const config = makeConfig({
+			capability: "builder",
+			slashCommands: [{ name: "pai", description: "Plan pipeline", availableTo: ["coordinator"] }],
+		});
+		const output = await generateOverlay(config);
+		expect(output).not.toContain("Available Slash Commands");
+	});
+
+	test("renders slash commands matching agent capability", async () => {
+		const config = makeConfig({
+			capability: "lead",
+			slashCommands: [
+				{
+					name: "pai",
+					description: "Plan-then-implement pipeline",
+					availableTo: ["coordinator", "lead"],
+				},
+				{ name: "loop", description: "Parallel fan-out", availableTo: ["coordinator", "lead"] },
+				{ name: "colony", description: "Hive-mind orchestration", availableTo: ["coordinator"] },
+			],
+		});
+		const output = await generateOverlay(config);
+		expect(output).toContain("Available Slash Commands");
+		expect(output).toContain("`/pai`");
+		expect(output).toContain("`/loop`");
+		// colony is coordinator-only, should not appear for lead
+		expect(output).not.toContain("`/colony`");
+	});
+});
+
+describe("tracking rendering", () => {
+	test("omits tracking section for leaf agents", async () => {
+		const config = makeConfig({
+			capability: "builder",
+			trackingProvider: "external",
+			trackingAgents: {
+				trackManager: "track-manager.md",
+				dependencyManager: "dependency-manager.md",
+			},
+		});
+		const output = await generateOverlay(config);
+		expect(output).not.toContain("Task Tracking (External)");
+	});
+
+	test("omits tracking section when provider is builtin", async () => {
+		const config = makeConfig({
+			capability: "coordinator",
+			trackingProvider: "builtin",
+		});
+		const output = await generateOverlay(config);
+		expect(output).not.toContain("Task Tracking (External)");
+	});
+
+	test("renders external tracking section for coordinator", async () => {
+		const config = makeConfig({
+			capability: "coordinator",
+			trackingProvider: "external",
+			trackingAgents: {
+				trackManager: "track-manager.md",
+				dependencyManager: "dependency-manager.md",
+			},
+		});
+		const output = await generateOverlay(config);
+		expect(output).toContain("Task Tracking (External)");
+		expect(output).toContain("track-manager.md");
+		expect(output).toContain("dependency-manager.md");
+	});
+
+	test("renders external tracking section for supervisor", async () => {
+		const config = makeConfig({
+			capability: "supervisor",
+			trackingProvider: "external",
+			trackingAgents: {
+				trackManager: "track-manager.md",
+				dependencyManager: "dependency-manager.md",
+			},
+		});
+		const output = await generateOverlay(config);
+		expect(output).toContain("Task Tracking (External)");
+	});
+
+	test("renders external tracking section for lead", async () => {
+		const config = makeConfig({
+			capability: "lead",
+			trackingProvider: "external",
+			trackingAgents: {
+				trackManager: "track-manager.md",
+				dependencyManager: "dependency-manager.md",
+			},
+		});
+		const output = await generateOverlay(config);
+		expect(output).toContain("Task Tracking (External)");
+	});
+});
+
 describe("isCanonicalRoot", () => {
 	test("returns true when dir matches canonicalRoot", () => {
 		expect(isCanonicalRoot("/projects/my-app", "/projects/my-app")).toBe(true);

--- a/src/agents/overlay.ts
+++ b/src/agents/overlay.ts
@@ -53,6 +53,85 @@ function formatMulchExpertise(expertise: string | undefined): string {
 	].join("\n");
 }
 
+/**
+ * Format tags for embedding in the overlay.
+ * Returns empty string if no tags are provided (omits the section entirely).
+ * When tags ARE provided, renders them as a specialization section.
+ */
+function formatTags(tags: readonly string[] | undefined): string {
+	if (!tags || tags.length === 0) {
+		return "";
+	}
+	return [
+		"## Specialization",
+		"",
+		`Tags: ${tags.join(", ")}`,
+		"Your work should reflect expertise in these areas.",
+		"",
+	].join("\n");
+}
+
+/**
+ * Format slash commands section for embedding in the overlay.
+ * Returns empty string if no slash commands are configured for this agent's capability.
+ * When commands ARE available, renders them as a reference section.
+ */
+function formatSlashCommands(config: OverlayConfig): string {
+	if (!config.slashCommands || config.slashCommands.length === 0) {
+		return "";
+	}
+	const available = config.slashCommands.filter((cmd) =>
+		cmd.availableTo.includes(config.capability),
+	);
+	if (available.length === 0) {
+		return "";
+	}
+	const lines: string[] = [
+		"## Available Slash Commands",
+		"",
+		"These user slash commands are available for your capability:",
+		"",
+		"| Command | Description |",
+		"|---------|-------------|",
+	];
+	for (const cmd of available) {
+		lines.push(`| \`/${cmd.name}\` | ${cmd.description} |`);
+	}
+	lines.push("");
+	return lines.join("\n");
+}
+
+/**
+ * Format tracking section for embedding in the overlay.
+ * Returns empty string for leaf agents (builder, scout, reviewer, merger).
+ * For coordination-capable agents (coordinator, supervisor, lead), shows
+ * which tracking system to use for batch coordination.
+ */
+function formatTracking(config: OverlayConfig): string {
+	// Only coordination-capable agents need tracking instructions
+	const coordinationCapabilities = new Set(["coordinator", "supervisor", "lead"]);
+	if (!coordinationCapabilities.has(config.capability)) {
+		return "";
+	}
+	if (!config.trackingProvider || config.trackingProvider === "builtin") {
+		return "";
+	}
+	if (config.trackingProvider === "external" && config.trackingAgents) {
+		return [
+			"## Task Tracking (External)",
+			"",
+			"This project uses external agents for task tracking instead of `overstory group`:",
+			"",
+			`- **Track Manager:** \`${config.trackingAgents.trackManager}\` — creates/manages parallel work tracks, assigns agents, updates status`,
+			`- **Dependency Manager:** \`${config.trackingAgents.dependencyManager}\` — analyzes dependencies, detects cycles, checks readiness`,
+			"",
+			"Use these agents (via slash commands or direct delegation) instead of `overstory group create/status/add/remove`.",
+			"",
+		].join("\n");
+	}
+	return "";
+}
+
 /** Capabilities that are read-only and should not get quality gates for commits/tests/lint. */
 const READ_ONLY_CAPABILITIES = new Set(["scout", "reviewer"]);
 
@@ -219,6 +298,9 @@ export async function generateOverlay(config: OverlayConfig): Promise<string> {
 		"{{CONSTRAINTS}}": formatConstraints(config),
 		"{{SPEC_INSTRUCTION}}": specInstruction,
 		"{{SKIP_SCOUT}}": config.skipScout ? SKIP_SCOUT_SECTION : "",
+		"{{TAGS}}": formatTags(config.tags),
+		"{{SLASH_COMMANDS}}": formatSlashCommands(config),
+		"{{TRACKING}}": formatTracking(config),
 		"{{BASE_DEFINITION}}": config.baseDefinition,
 		"{{TRACKER_CLI}}": config.trackerCli ?? "bd",
 		"{{TRACKER_NAME}}": config.trackerName ?? "beads",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -199,6 +199,7 @@ function buildAgentManifest(): AgentManifest {
 			capabilities: ["explore", "research"],
 			canSpawn: false,
 			constraints: ["read-only"],
+			tags: ["exploration", "research"],
 		},
 		builder: {
 			file: "builder.md",
@@ -207,6 +208,7 @@ function buildAgentManifest(): AgentManifest {
 			capabilities: ["implement", "refactor", "fix"],
 			canSpawn: false,
 			constraints: [],
+			tags: ["implementation"],
 		},
 		reviewer: {
 			file: "reviewer.md",
@@ -215,6 +217,7 @@ function buildAgentManifest(): AgentManifest {
 			capabilities: ["review", "validate"],
 			canSpawn: false,
 			constraints: ["read-only"],
+			tags: ["code-quality", "validation"],
 		},
 		lead: {
 			file: "lead.md",
@@ -223,6 +226,7 @@ function buildAgentManifest(): AgentManifest {
 			capabilities: ["coordinate", "implement", "review"],
 			canSpawn: true,
 			constraints: [],
+			tags: ["coordination", "planning"],
 		},
 		merger: {
 			file: "merger.md",
@@ -231,6 +235,7 @@ function buildAgentManifest(): AgentManifest {
 			capabilities: ["merge", "resolve-conflicts"],
 			canSpawn: false,
 			constraints: [],
+			tags: ["merge", "conflict-resolution"],
 		},
 		coordinator: {
 			file: "coordinator.md",
@@ -239,6 +244,7 @@ function buildAgentManifest(): AgentManifest {
 			capabilities: ["coordinate", "dispatch", "escalate"],
 			canSpawn: true,
 			constraints: ["read-only", "no-worktree"],
+			tags: ["dispatch", "orchestration"],
 		},
 		supervisor: {
 			file: "supervisor.md",
@@ -247,6 +253,7 @@ function buildAgentManifest(): AgentManifest {
 			capabilities: ["coordinate", "supervise"],
 			canSpawn: true,
 			constraints: [],
+			tags: ["supervision", "coordination"],
 		},
 		monitor: {
 			file: "monitor.md",
@@ -255,6 +262,7 @@ function buildAgentManifest(): AgentManifest {
 			capabilities: ["monitor", "patrol"],
 			canSpawn: false,
 			constraints: ["read-only", "no-worktree"],
+			tags: ["monitoring", "patrol"],
 		},
 	};
 
@@ -271,7 +279,21 @@ function buildAgentManifest(): AgentManifest {
 		}
 	}
 
-	return { version: "1.0", agents, capabilityIndex };
+	// Build tag index: map each tag to agent names that declare it
+	const tagIndex: Record<string, string[]> = {};
+	for (const [name, def] of Object.entries(agents)) {
+		if (!def.tags) continue;
+		for (const tag of def.tags) {
+			const existing = tagIndex[tag];
+			if (existing) {
+				existing.push(name);
+			} else {
+				tagIndex[tag] = [name];
+			}
+		}
+	}
+
+	return { version: "1.0", agents, capabilityIndex, tagIndex };
 }
 
 /**

--- a/src/commands/sling.ts
+++ b/src/commands/sling.ts
@@ -22,7 +22,12 @@ import { mkdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { deployHooks } from "../agents/hooks-deployer.ts";
 import { createIdentity, loadIdentity } from "../agents/identity.ts";
-import { createManifestLoader, resolveModel } from "../agents/manifest.ts";
+import {
+	createManifestLoader,
+	parseAgentFrontmatter,
+	resolveModel,
+	resolveUserAgent,
+} from "../agents/manifest.ts";
 import { writeOverlay } from "../agents/overlay.ts";
 import { loadConfig } from "../config.ts";
 import { AgentError, HierarchyError, ValidationError } from "../errors.ts";
@@ -478,10 +483,41 @@ export async function slingCommand(args: string[]): Promise<void> {
 		});
 
 		// 8. Generate + write overlay CLAUDE.md
-		const agentDefPath = join(config.project.root, config.agents.baseDir, agentDef.file);
-		const baseDefinition = await Bun.file(agentDefPath).text();
+		// 8a. Resolve base definition: check for capability alias to user agent first
+		let baseDefinition: string;
+		let overlayTags: string[] | undefined;
+		const alias = config.agents.capabilityAliases[capability];
 
-		// 8a. Fetch file-scoped mulch expertise if mulch is enabled and files are provided
+		if (alias && config.agents.userAgentDir) {
+			// Try to resolve user agent file as Layer 1 base
+			const userContent = await resolveUserAgent(
+				config.agents.userAgentDir,
+				alias.userAgent,
+			);
+			if (userContent) {
+				// Use the user agent body (strip frontmatter) as the base definition
+				const { body } = parseAgentFrontmatter(userContent);
+				baseDefinition = body;
+				overlayTags = alias.tags;
+			} else {
+				// Fallback to default overstory agent definition
+				const agentDefPath = join(config.project.root, config.agents.baseDir, agentDef.file);
+				baseDefinition = await Bun.file(agentDefPath).text();
+				process.stderr.write(
+					`[overstory] Warning: user agent "${alias.userAgent}" not found in "${config.agents.userAgentDir}". Falling back to default ${capability} definition.\n`,
+				);
+			}
+		} else {
+			const agentDefPath = join(config.project.root, config.agents.baseDir, agentDef.file);
+			baseDefinition = await Bun.file(agentDefPath).text();
+		}
+
+		// Also pick up tags from the manifest agent definition if no alias tags
+		if (!overlayTags && agentDef.tags) {
+			overlayTags = agentDef.tags;
+		}
+
+		// 8b. Fetch file-scoped mulch expertise if mulch is enabled and files are provided
 		let mulchExpertise: string | undefined;
 		if (config.mulch.enabled && fileScope.length > 0) {
 			try {
@@ -513,6 +549,7 @@ export async function slingCommand(args: string[]): Promise<void> {
 			qualityGates: config.project.qualityGates,
 			trackerCli: trackerCliName(resolvedBackend),
 			trackerName: resolvedBackend,
+			tags: overlayTags,
 		};
 
 		try {

--- a/src/commands/spec.test.ts
+++ b/src/commands/spec.test.ts
@@ -9,7 +9,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { cleanupTempDir, createTempGitRepo } from "../test-helpers.ts";
-import { specCommand, writeSpec } from "./spec.ts";
+import { generateSpecTemplate, specCommand, writeSpec } from "./spec.ts";
 
 let tempDir: string;
 let overstoryDir: string;
@@ -199,5 +199,97 @@ describe("specCommand write", () => {
 		const content = await Bun.file(specPath).text();
 		expect(content).toContain("<!-- written-by: scout-3 -->");
 		expect(content).toContain("# Content");
+	});
+});
+
+// === generateSpecTemplate ===
+
+describe("generateSpecTemplate", () => {
+	test("generates scaffold with all 14+4 sections", () => {
+		const template = generateSpecTemplate("task-tmpl");
+		expect(template).toContain("# task-tmpl");
+		expect(template).toContain("## Why");
+		expect(template).toContain("## Design Principles");
+		expect(template).toContain("## On-Disk Format");
+		expect(template).toContain("## Data Model");
+		expect(template).toContain("## CLI");
+		expect(template).toContain("## JSON Output Format");
+		expect(template).toContain("## Concurrency Model");
+		expect(template).toContain("## Migration");
+		expect(template).toContain("## Integration");
+		expect(template).toContain("## What It Does NOT Do");
+		expect(template).toContain("## Tech Stack");
+		expect(template).toContain("## Project Infrastructure");
+		expect(template).toContain("## Estimated Size");
+		expect(template).toContain("## Agent Assignments");
+		expect(template).toContain("## Execution Order");
+		expect(template).toContain("## Failure Modes");
+		expect(template).toContain("## Success Criteria");
+	});
+
+	test("includes TODO placeholders", () => {
+		const template = generateSpecTemplate("task-tmpl");
+		expect(template).toContain("<!-- TODO: fill in this section -->");
+	});
+
+	test("includes body content under title when provided", () => {
+		const template = generateSpecTemplate("task-ctx", "This is context for the task");
+		expect(template).toContain("# task-ctx");
+		expect(template).toContain("This is context for the task");
+		// Body should appear before the first section heading
+		const bodyIdx = template.indexOf("This is context");
+		const whyIdx = template.indexOf("## Why");
+		expect(bodyIdx).toBeLessThan(whyIdx);
+	});
+
+	test("omits body section when not provided", () => {
+		const template = generateSpecTemplate("task-nobody");
+		// Title line followed by empty line then first section
+		const lines = template.split("\n");
+		expect(lines[0]).toBe("# task-nobody");
+		expect(lines[1]).toBe("");
+		expect(lines[2]).toBe("## Why");
+	});
+});
+
+// === specCommand write --template ===
+
+describe("specCommand write --template", () => {
+	test("--template generates scaffold without --body", async () => {
+		await specCommand(["write", "task-scaffold", "--template"]);
+
+		expect(stdoutOutput.trim()).toContain(".overstory/specs/task-scaffold.md");
+
+		const specPath = stdoutOutput.trim();
+		const content = await Bun.file(specPath).text();
+		expect(content).toContain("# task-scaffold");
+		expect(content).toContain("## Why");
+		expect(content).toContain("## Success Criteria");
+		expect(content).toContain("<!-- TODO: fill in this section -->");
+	});
+
+	test("--template with --body includes body as context", async () => {
+		await specCommand([
+			"write",
+			"task-ctx",
+			"--template",
+			"--body",
+			"Migrate auth from sessions to JWT",
+		]);
+
+		const specPath = stdoutOutput.trim();
+		const content = await Bun.file(specPath).text();
+		expect(content).toContain("# task-ctx");
+		expect(content).toContain("Migrate auth from sessions to JWT");
+		expect(content).toContain("## Why");
+	});
+
+	test("--template with --agent adds attribution", async () => {
+		await specCommand(["write", "task-tmpl-agent", "--template", "--agent", "scout-5"]);
+
+		const specPath = stdoutOutput.trim();
+		const content = await Bun.file(specPath).text();
+		expect(content).toContain("<!-- written-by: scout-5 -->");
+		expect(content).toContain("## Why");
 	});
 });

--- a/src/commands/spec.ts
+++ b/src/commands/spec.ts
@@ -13,7 +13,7 @@ import { join } from "node:path";
 import { ValidationError } from "../errors.ts";
 
 /** Boolean flags that do NOT consume the next arg. */
-const BOOLEAN_FLAGS = new Set(["--help", "-h"]);
+const BOOLEAN_FLAGS = new Set(["--help", "-h", "--template"]);
 
 /**
  * Parse a named flag value from args.
@@ -51,6 +51,53 @@ function getPositionalArgs(args: string[]): string[] {
 }
 
 /**
+ * The 14-section spec template structure based on the user's spec-builder agent.
+ * Each section is a heading that scaffolds a comprehensive task specification.
+ * Execution sections (Agent Assignments, Execution Order, etc.) follow the core 14.
+ */
+const SPEC_TEMPLATE_SECTIONS = [
+	"## Why",
+	"## Design Principles",
+	"## On-Disk Format",
+	"## Data Model",
+	"## CLI",
+	"## JSON Output Format",
+	"## Concurrency Model",
+	"## Migration",
+	"## Integration",
+	"## What It Does NOT Do",
+	"## Tech Stack",
+	"## Project Infrastructure",
+	"## Estimated Size",
+	"## Agent Assignments",
+	"## Execution Order",
+	"## Failure Modes",
+	"## Success Criteria",
+] as const;
+
+/**
+ * Generate a spec scaffold from the 14-section template.
+ * If body content is provided, it is placed under the title heading.
+ * Otherwise, each section gets a placeholder comment.
+ */
+export function generateSpecTemplate(beadId: string, body?: string): string {
+	const lines: string[] = [];
+	lines.push(`# ${beadId}`);
+	lines.push("");
+	if (body && body.trim().length > 0) {
+		lines.push(body.trim());
+		lines.push("");
+	}
+	for (const section of SPEC_TEMPLATE_SECTIONS) {
+		lines.push(section);
+		lines.push("");
+		lines.push("<!-- TODO: fill in this section -->");
+		lines.push("");
+	}
+	return lines.join("\n");
+}
+
+/**
  * Read all of stdin as a string. Returns empty string if stdin is a TTY
  * (no piped input).
  */
@@ -72,12 +119,15 @@ Subcommands:
 Options for 'write':
   --body <content>         Spec content (or pipe via stdin)
   --agent <name>           Agent writing the spec (for attribution)
+  --template               Scaffold with 14-section spec-builder template
   --help, -h               Show this help
 
 Examples:
   overstory spec write task-abc --body "# Spec\\nDetails here..."
   echo "# Spec" | overstory spec write task-abc
-  overstory spec write task-abc --body "..." --agent scout-1`;
+  overstory spec write task-abc --body "..." --agent scout-1
+  overstory spec write task-abc --template
+  overstory spec write task-abc --template --body "Context for this task"`;
 
 /**
  * Write a spec file to .overstory/specs/<bead-id>.md.
@@ -135,17 +185,21 @@ export async function specCommand(args: string[]): Promise<void> {
 			}
 
 			const agent = getFlag(subArgs, "--agent");
+			const useTemplate = subArgs.includes("--template");
 			let body = getFlag(subArgs, "--body");
 
-			// If no --body flag, try reading from stdin
-			if (body === undefined) {
+			// If no --body flag and not in template mode, try reading from stdin
+			if (body === undefined && !useTemplate) {
 				const stdinContent = await readStdin();
 				if (stdinContent.trim().length > 0) {
 					body = stdinContent;
 				}
 			}
 
-			if (body === undefined || body.trim().length === 0) {
+			// --template mode: generate scaffold (body is optional context)
+			if (useTemplate) {
+				body = generateSpecTemplate(beadId, body ?? undefined);
+			} else if (body === undefined || body.trim().length === 0) {
 				throw new ValidationError("Spec body is required: use --body <content> or pipe via stdin", {
 					field: "body",
 				});
@@ -154,7 +208,7 @@ export async function specCommand(args: string[]): Promise<void> {
 			const { resolveProjectRoot } = await import("../config.ts");
 			const projectRoot = await resolveProjectRoot(process.cwd());
 
-			const specPath = await writeSpec(projectRoot, beadId, body, agent);
+			const specPath = await writeSpec(projectRoot, beadId, body as string, agent);
 			process.stdout.write(`${specPath}\n`);
 			break;
 		}

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -819,4 +819,14 @@ describe("DEFAULT_CONFIG", () => {
 		expect(DEFAULT_QUALITY_GATES[1]?.name).toBe("Lint");
 		expect(DEFAULT_QUALITY_GATES[2]?.name).toBe("Typecheck");
 	});
+
+	test("has default slashCommands as empty array", () => {
+		expect(DEFAULT_CONFIG.slashCommands).toEqual([]);
+	});
+
+	test("has default tracking config with builtin provider", () => {
+		expect(DEFAULT_CONFIG.tracking.provider).toBe("builtin");
+		expect(DEFAULT_CONFIG.tracking.externalAgents.trackManager).toBe("");
+		expect(DEFAULT_CONFIG.tracking.externalAgents.dependencyManager).toBe("");
+	});
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,8 @@ export const DEFAULT_CONFIG: OverstoryConfig = {
 		staggerDelayMs: 2_000,
 		maxDepth: 2,
 		maxSessionsPerRun: 0,
+		userAgentDir: "",
+		capabilityAliases: {},
 	},
 	worktrees: {
 		baseDir: ".overstory/worktrees",
@@ -60,6 +62,14 @@ export const DEFAULT_CONFIG: OverstoryConfig = {
 	logging: {
 		verbose: false,
 		redactSecrets: true,
+	},
+	slashCommands: [],
+	tracking: {
+		provider: "builtin",
+		externalAgents: {
+			trackManager: "",
+			dependencyManager: "",
+		},
 	},
 };
 
@@ -499,6 +509,48 @@ function validateConfig(config: OverstoryConfig): void {
 		);
 	}
 
+	// agents.userAgentDir must be a string (empty string = disabled)
+	if (typeof config.agents.userAgentDir !== "string") {
+		throw new ValidationError("agents.userAgentDir must be a string (empty string to disable)", {
+			field: "agents.userAgentDir",
+			value: config.agents.userAgentDir,
+		});
+	}
+
+	// agents.capabilityAliases must be an object if present
+	if (
+		config.agents.capabilityAliases !== null &&
+		typeof config.agents.capabilityAliases === "object"
+	) {
+		for (const [cap, alias] of Object.entries(config.agents.capabilityAliases)) {
+			if (alias === null || typeof alias !== "object") {
+				throw new ValidationError(`agents.capabilityAliases.${cap} must be an object`, {
+					field: `agents.capabilityAliases.${cap}`,
+					value: alias,
+				});
+			}
+			const a = alias as unknown as Record<string, unknown>;
+			if (typeof a.userAgent !== "string" || a.userAgent.length === 0) {
+				throw new ValidationError(
+					`agents.capabilityAliases.${cap}.userAgent must be a non-empty string`,
+					{
+						field: `agents.capabilityAliases.${cap}.userAgent`,
+						value: a.userAgent,
+					},
+				);
+			}
+			if (a.tags !== undefined && !Array.isArray(a.tags)) {
+				throw new ValidationError(
+					`agents.capabilityAliases.${cap}.tags must be an array if present`,
+					{
+						field: `agents.capabilityAliases.${cap}.tags`,
+						value: a.tags,
+					},
+				);
+			}
+		}
+	}
+
 	// watchdog intervals must be positive if enabled
 	if (config.watchdog.tier0Enabled && config.watchdog.tier0IntervalMs <= 0) {
 		throw new ValidationError("watchdog.tier0IntervalMs must be positive when tier0 is enabled", {
@@ -646,6 +698,73 @@ function validateConfig(config: OverstoryConfig): void {
 					},
 				);
 			}
+		}
+	}
+
+	// slashCommands: validate each entry if present
+	if (config.slashCommands && Array.isArray(config.slashCommands)) {
+		for (let i = 0; i < config.slashCommands.length; i++) {
+			const cmd = config.slashCommands[i];
+			if (!cmd) continue;
+			if (!cmd.name || typeof cmd.name !== "string") {
+				throw new ValidationError(`slashCommands[${i}].name must be a non-empty string`, {
+					field: `slashCommands[${i}].name`,
+					value: cmd.name,
+				});
+			}
+			if (!cmd.description || typeof cmd.description !== "string") {
+				throw new ValidationError(`slashCommands[${i}].description must be a non-empty string`, {
+					field: `slashCommands[${i}].description`,
+					value: cmd.description,
+				});
+			}
+			if (!Array.isArray(cmd.availableTo) || cmd.availableTo.length === 0) {
+				throw new ValidationError(
+					`slashCommands[${i}].availableTo must be a non-empty array of capability names`,
+					{
+						field: `slashCommands[${i}].availableTo`,
+						value: cmd.availableTo,
+					},
+				);
+			}
+		}
+	}
+
+	// tracking: validate provider and externalAgents
+	const validTrackingProviders = ["builtin", "external"];
+	if (!validTrackingProviders.includes(config.tracking.provider)) {
+		throw new ValidationError(
+			`tracking.provider must be one of: ${validTrackingProviders.join(", ")}`,
+			{
+				field: "tracking.provider",
+				value: config.tracking.provider,
+			},
+		);
+	}
+	if (config.tracking.provider === "external") {
+		if (
+			!config.tracking.externalAgents.trackManager ||
+			typeof config.tracking.externalAgents.trackManager !== "string"
+		) {
+			throw new ValidationError(
+				"tracking.externalAgents.trackManager must be a non-empty string when provider is 'external'",
+				{
+					field: "tracking.externalAgents.trackManager",
+					value: config.tracking.externalAgents.trackManager,
+				},
+			);
+		}
+		if (
+			!config.tracking.externalAgents.dependencyManager ||
+			typeof config.tracking.externalAgents.dependencyManager !== "string"
+		) {
+			throw new ValidationError(
+				"tracking.externalAgents.dependencyManager must be a non-empty string when provider is 'external'",
+				{
+					field: "tracking.externalAgents.dependencyManager",
+					value: config.tracking.externalAgents.dependencyManager,
+				},
+			);
 		}
 	}
 }

--- a/src/doctor/agents.test.ts
+++ b/src/doctor/agents.test.ts
@@ -35,6 +35,8 @@ describe("checkAgents", () => {
 				staggerDelayMs: 1000,
 				maxDepth: 2,
 				maxSessionsPerRun: 0,
+				userAgentDir: "",
+				capabilityAliases: {},
 			},
 			worktrees: {
 				baseDir: ".overstory/worktrees",
@@ -68,6 +70,11 @@ describe("checkAgents", () => {
 			logging: {
 				verbose: false,
 				redactSecrets: true,
+			},
+			slashCommands: [],
+			tracking: {
+				provider: "builtin" as const,
+				externalAgents: { trackManager: "", dependencyManager: "" },
 			},
 		};
 	});

--- a/src/doctor/config-check.test.ts
+++ b/src/doctor/config-check.test.ts
@@ -42,6 +42,8 @@ const mockConfig: OverstoryConfig = {
 		staggerDelayMs: 1000,
 		maxDepth: 2,
 		maxSessionsPerRun: 0,
+		userAgentDir: "",
+		capabilityAliases: {},
 	},
 	worktrees: {
 		baseDir: `${tmpdir()}/.overstory/worktrees`,
@@ -75,6 +77,11 @@ const mockConfig: OverstoryConfig = {
 	logging: {
 		verbose: false,
 		redactSecrets: true,
+	},
+	slashCommands: [],
+	tracking: {
+		provider: "builtin" as const,
+		externalAgents: { trackManager: "", dependencyManager: "" },
 	},
 };
 

--- a/src/doctor/consistency.test.ts
+++ b/src/doctor/consistency.test.ts
@@ -76,6 +76,8 @@ describe("checkConsistency", () => {
 				staggerDelayMs: 100,
 				maxDepth: 2,
 				maxSessionsPerRun: 0,
+				userAgentDir: "",
+				capabilityAliases: {},
 			},
 			worktrees: {
 				baseDir: join(overstoryDir, "worktrees"),
@@ -109,6 +111,11 @@ describe("checkConsistency", () => {
 			logging: {
 				verbose: false,
 				redactSecrets: true,
+			},
+			slashCommands: [],
+			tracking: {
+				provider: "builtin" as const,
+				externalAgents: { trackManager: "", dependencyManager: "" },
 			},
 		};
 

--- a/src/doctor/databases.test.ts
+++ b/src/doctor/databases.test.ts
@@ -22,6 +22,8 @@ describe("checkDatabases", () => {
 				staggerDelayMs: 100,
 				maxDepth: 2,
 				maxSessionsPerRun: 0,
+				userAgentDir: "",
+				capabilityAliases: {},
 			},
 			worktrees: { baseDir: "" },
 			taskTracker: { backend: "auto", enabled: true },
@@ -41,6 +43,11 @@ describe("checkDatabases", () => {
 			},
 			models: {},
 			logging: { verbose: false, redactSecrets: true },
+			slashCommands: [],
+			tracking: {
+				provider: "builtin" as const,
+				externalAgents: { trackManager: "", dependencyManager: "" },
+			},
 		};
 	});
 

--- a/src/doctor/dependencies.test.ts
+++ b/src/doctor/dependencies.test.ts
@@ -16,6 +16,8 @@ const mockConfig: OverstoryConfig = {
 		staggerDelayMs: 1000,
 		maxDepth: 2,
 		maxSessionsPerRun: 0,
+		userAgentDir: "",
+		capabilityAliases: {},
 	},
 	worktrees: {
 		baseDir: "/tmp/.overstory/worktrees",
@@ -49,6 +51,11 @@ const mockConfig: OverstoryConfig = {
 	logging: {
 		verbose: false,
 		redactSecrets: true,
+	},
+	slashCommands: [],
+	tracking: {
+		provider: "builtin" as const,
+		externalAgents: { trackManager: "", dependencyManager: "" },
 	},
 };
 

--- a/src/doctor/logs.test.ts
+++ b/src/doctor/logs.test.ts
@@ -36,6 +36,8 @@ describe("checkLogs", () => {
 				staggerDelayMs: 1000,
 				maxDepth: 2,
 				maxSessionsPerRun: 0,
+				userAgentDir: "",
+				capabilityAliases: {},
 			},
 			worktrees: {
 				baseDir: ".overstory/worktrees",
@@ -69,6 +71,11 @@ describe("checkLogs", () => {
 			logging: {
 				verbose: false,
 				redactSecrets: true,
+			},
+			slashCommands: [],
+			tracking: {
+				provider: "builtin" as const,
+				externalAgents: { trackManager: "", dependencyManager: "" },
 			},
 		};
 

--- a/src/doctor/merge-queue.test.ts
+++ b/src/doctor/merge-queue.test.ts
@@ -23,6 +23,8 @@ describe("checkMergeQueue", () => {
 				staggerDelayMs: 100,
 				maxDepth: 2,
 				maxSessionsPerRun: 0,
+				userAgentDir: "",
+				capabilityAliases: {},
 			},
 			worktrees: { baseDir: "" },
 			taskTracker: { backend: "auto", enabled: true },
@@ -42,6 +44,11 @@ describe("checkMergeQueue", () => {
 			},
 			models: {},
 			logging: { verbose: false, redactSecrets: true },
+			slashCommands: [],
+			tracking: {
+				provider: "builtin" as const,
+				externalAgents: { trackManager: "", dependencyManager: "" },
+			},
 		};
 	});
 

--- a/src/doctor/structure.test.ts
+++ b/src/doctor/structure.test.ts
@@ -34,6 +34,8 @@ describe("checkStructure", () => {
 				staggerDelayMs: 1000,
 				maxDepth: 2,
 				maxSessionsPerRun: 0,
+				userAgentDir: "",
+				capabilityAliases: {},
 			},
 			worktrees: {
 				baseDir: ".overstory/worktrees",
@@ -67,6 +69,11 @@ describe("checkStructure", () => {
 			logging: {
 				verbose: false,
 				redactSecrets: true,
+			},
+			slashCommands: [],
+			tracking: {
+				provider: "builtin" as const,
+				externalAgents: { trackManager: "", dependencyManager: "" },
 			},
 		};
 	});

--- a/src/doctor/version.test.ts
+++ b/src/doctor/version.test.ts
@@ -16,6 +16,8 @@ const mockConfig: OverstoryConfig = {
 		staggerDelayMs: 1000,
 		maxDepth: 2,
 		maxSessionsPerRun: 0,
+		userAgentDir: "",
+		capabilityAliases: {},
 	},
 	worktrees: {
 		baseDir: "/tmp/.overstory/worktrees",
@@ -49,6 +51,11 @@ const mockConfig: OverstoryConfig = {
 	logging: {
 		verbose: false,
 		redactSecrets: true,
+	},
+	slashCommands: [],
+	tracking: {
+		provider: "builtin" as const,
+		externalAgents: { trackManager: "", dependencyManager: "" },
 	},
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,37 @@ export interface ResolvedModel {
 /** Backend for the task tracker. Defined here for use in OverstoryConfig. */
 export type TaskTrackerBackend = "auto" | "seeds" | "beads";
 
+// === Capability Aliases ===
+
+/** Maps an overstory capability to a user agent file for Layer 1 base override. */
+export interface CapabilityAlias {
+	userAgent: string; // Filename of user agent definition (e.g., "unix-coder.md")
+	tags?: string[]; // Optional tags for specialization (e.g., ["security", "code-quality"])
+}
+
+// === Slash Command Integration ===
+
+/** A user slash command exposed to overstory agents via the overlay. */
+export interface SlashCommandConfig {
+	name: string; // Command name without leading slash (e.g., "pai")
+	description: string; // What the command does (one line)
+	availableTo: string[]; // Capabilities that can use this command (e.g., ["coordinator", "lead"])
+}
+
+// === Tracking Provider ===
+
+/** Whether to use overstory's built-in group+beads or external track-manager agents. */
+export type TrackingProvider = "builtin" | "external";
+
+/** Configuration for the tracking/coordination subsystem. */
+export interface TrackingConfig {
+	provider: TrackingProvider; // "builtin" = overstory group+beads, "external" = user agents
+	externalAgents: {
+		trackManager: string; // Path or filename of track-manager agent (e.g., "track-manager.md")
+		dependencyManager: string; // Path or filename of dependency-manager agent
+	};
+}
+
 // === Project Configuration ===
 
 /** A single quality gate command that agents must pass before reporting completion. */
@@ -53,6 +84,8 @@ export interface OverstoryConfig {
 		staggerDelayMs: number; // Delay between spawns
 		maxDepth: number; // Hierarchy depth limit (default 2)
 		maxSessionsPerRun: number; // Max total sessions per run (0 = unlimited)
+		userAgentDir: string; // Path to user agent definitions (e.g., ~/.claude/agents), empty = disabled
+		capabilityAliases: Record<string, CapabilityAlias>; // Maps capabilities to user agent files
 	};
 	worktrees: {
 		baseDir: string; // Where worktrees live
@@ -85,6 +118,8 @@ export interface OverstoryConfig {
 		verbose: boolean;
 		redactSecrets: boolean;
 	};
+	slashCommands: SlashCommandConfig[]; // User slash commands available to agents
+	tracking: TrackingConfig; // Coordination subsystem provider
 }
 
 // === Agent Manifest ===
@@ -93,6 +128,7 @@ export interface AgentManifest {
 	version: string;
 	agents: Record<string, AgentDefinition>;
 	capabilityIndex: Record<string, string[]>;
+	tagIndex?: Record<string, string[]>; // Maps tags to agent names
 }
 
 export interface AgentDefinition {
@@ -102,6 +138,7 @@ export interface AgentDefinition {
 	capabilities: string[]; // What this agent can do
 	canSpawn: boolean; // Can this agent spawn sub-workers?
 	constraints: string[]; // Machine-readable restrictions
+	tags?: string[]; // Optional tags for specialization (e.g., "security", "code-quality")
 }
 
 /** All valid agent capability types. Used for compile-time validation. */
@@ -304,6 +341,14 @@ export interface OverlayConfig {
 	trackerName?: string; // "seeds" or "beads"
 	/** Quality gate commands for the agent overlay. Falls back to defaults if undefined. */
 	qualityGates?: QualityGate[];
+	/** Optional tags for agent specialization (e.g., "security", "code-quality"). */
+	tags?: string[];
+	/** Slash commands available to this agent based on its capability. */
+	slashCommands?: SlashCommandConfig[];
+	/** Tracking provider configuration for coordination-capable agents. */
+	trackingProvider?: TrackingProvider;
+	/** External tracking agent names (when tracking.provider is "external"). */
+	trackingAgents?: { trackManager: string; dependencyManager: string };
 }
 
 // === Merge Queue ===

--- a/templates/overlay.md.tmpl
+++ b/templates/overlay.md.tmpl
@@ -21,6 +21,12 @@
 
 {{SKIP_SCOUT}}
 
+{{TAGS}}
+
+{{SLASH_COMMANDS}}
+
+{{TRACKING}}
+
 ## Working Directory
 
 Your worktree root is: `{{WORKTREE_PATH}}`


### PR DESCRIPTION
## Summary

- **Capabilities refactoring**: Tag-based agent specialization, user agent aliasing from `~/.claude/agents/`, slash command integration with `availableTo` filtering, tracking config bridge for external track/dependency managers
- **Tracker migration**: Replace beads (`bd`) with pluggable tracker abstraction (`src/tracker/`) supporting both beads and seeds backends
- **Canopy integration**: Agent prompt management via canopy
- **Quality gates**: Configurable per-project quality gate commands
- **Agent definitions**: All 8 agent `.md` files updated with Unix philosophy and one-word output conventions

## Test plan

- [x] `bun test` — 2050 pass, 16 pre-existing env-dependent skips
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] Merge conflicts with upstream resolved and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)