### PR TITLE
fix: use temp script when tmux command exceeds safe length

### DIFF
--- a/src/worktree/tmux.ts
+++ b/src/worktree/tmux.ts
@@ -107,8 +107,24 @@ export async function createSession(
 
 	const wrappedCommand = exports.length > 0 ? `${exports.join(" && ")} && ${command}` : command;
 
+	// tmux has an internal IPC message size limit (~8-16KB depending on version).
+	// When the command string (e.g. claude --append-system-prompt with a large agent
+	// definition) exceeds this limit, tmux returns "command too long". Work around
+	// this by writing the command to a temp shell script and passing the script path
+	// to tmux instead of the raw string.
+	const TMUX_CMD_SAFE_LIMIT = 8000;
+	let tmuxCmd = wrappedCommand;
+	if (wrappedCommand.length > TMUX_CMD_SAFE_LIMIT) {
+		const tmpPath = `/tmp/overstory-${name}-${Date.now()}.sh`;
+		await Bun.write(tmpPath, `#!/bin/sh\n${wrappedCommand}\n`);
+		const { exitCode: chmodExit } = await runCommand(["chmod", "+x", tmpPath]);
+		if (chmodExit === 0) {
+			tmuxCmd = tmpPath;
+		}
+	}
+
 	const { exitCode, stderr } = await runCommand(
-		["tmux", "new-session", "-d", "-s", name, "-c", cwd, wrappedCommand],
+		["tmux", "new-session", "-d", "-s", name, "-c", cwd, tmuxCmd],
 		cwd,
 	);
 


### PR DESCRIPTION
## Problem

`ov coordinator start` (and `ov sling`) fails with:

```
Error [AGENT_ERROR]: Failed to create tmux session "overstory-<project>-coordinator": command too long
```

## Root Cause

Large agent definition files (e.g. `coordinator.md` at ~16KB) are embedded inline as `--append-system-prompt '...'` in the `claude` CLI invocation. This full command string is then passed as a single positional argument to `tmux new-session`. tmux's internal IPC protocol has a message size limit (~8-16KB depending on version), causing it to reject the command with "command too long".

## Fix

In `createSession` (`src/worktree/tmux.ts`): when the wrapped command string exceeds 8,000 characters, write it to a temporary shell script in `/tmp` and pass the script path to tmux instead of the raw string. Behavior is identical — tmux runs the same commands — but the IPC message stays small.

## Testing

- All 66 existing tests in `src/worktree/tmux.test.ts` pass
- Biome: no issues
- TypeScript: no errors
- Manually verified `ov coordinator start` succeeds in a project with a 16KB coordinator.md