### PR TITLE
feat: add Codex runtime adapter

### DIFF
--- a/src/runtimes/claude.test.ts
+++ b/src/runtimes/claude.test.ts
@@ -651,7 +651,7 @@ describe("ClaudeRuntime integration: registry resolves 'claude' as default", () 
 
 	test("getRuntime rejects unknown runtimes", async () => {
 		const { getRuntime } = await import("./registry.ts");
-		expect(() => getRuntime("codex")).toThrow('Unknown runtime: "codex"');
 		expect(() => getRuntime("opencode")).toThrow('Unknown runtime: "opencode"');
+		expect(() => getRuntime("aider")).toThrow('Unknown runtime: "aider"');
 	});
 });

--- a/src/runtimes/codex.test.ts
+++ b/src/runtimes/codex.test.ts
@@ -1,0 +1,741 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ResolvedModel } from "../types.ts";
+import { CodexRuntime } from "./codex.ts";
+import type { SpawnOpts } from "./types.ts";
+
+describe("CodexRuntime", () => {
+	const runtime = new CodexRuntime();
+
+	describe("id and instructionPath", () => {
+		test("id is 'codex'", () => {
+			expect(runtime.id).toBe("codex");
+		});
+
+		test("instructionPath is AGENTS.md", () => {
+			expect(runtime.instructionPath).toBe("AGENTS.md");
+		});
+	});
+
+	describe("buildSpawnCommand", () => {
+		test("basic command uses codex exec with --full-auto and --json", () => {
+			const opts: SpawnOpts = {
+				model: "gpt-5-codex",
+				permissionMode: "bypass",
+				cwd: "/tmp/worktree",
+				env: {},
+			};
+			const cmd = runtime.buildSpawnCommand(opts);
+			expect(cmd).toContain("codex exec --full-auto --json");
+			expect(cmd).toContain("--model gpt-5-codex");
+			expect(cmd).toContain("Read AGENTS.md");
+		});
+
+		test("permissionMode is NOT included in command (Codex uses OS sandbox)", () => {
+			const opts: SpawnOpts = {
+				model: "gpt-5-codex",
+				permissionMode: "bypass",
+				cwd: "/tmp/worktree",
+				env: {},
+			};
+			const cmd = runtime.buildSpawnCommand(opts);
+			expect(cmd).not.toContain("--permission-mode");
+			expect(cmd).not.toContain("bypassPermissions");
+		});
+
+		test("ask permissionMode also excluded (OS sandbox enforces security)", () => {
+			const opts: SpawnOpts = {
+				model: "gpt-5-codex",
+				permissionMode: "ask",
+				cwd: "/tmp/worktree",
+				env: {},
+			};
+			const cmd = runtime.buildSpawnCommand(opts);
+			expect(cmd).not.toContain("--permission-mode");
+		});
+
+		test("with appendSystemPrompt prepends to the exec prompt", () => {
+			const opts: SpawnOpts = {
+				model: "gpt-5-codex",
+				permissionMode: "bypass",
+				cwd: "/tmp/worktree",
+				env: {},
+				appendSystemPrompt: "You are a builder agent.",
+			};
+			const cmd = runtime.buildSpawnCommand(opts);
+			expect(cmd).toContain("You are a builder agent.");
+			expect(cmd).toContain("Read AGENTS.md");
+		});
+
+		test("with appendSystemPrompt containing single quotes (POSIX escape)", () => {
+			const opts: SpawnOpts = {
+				model: "gpt-5-codex",
+				permissionMode: "bypass",
+				cwd: "/tmp/worktree",
+				env: {},
+				appendSystemPrompt: "Don't touch the user's files",
+			};
+			const cmd = runtime.buildSpawnCommand(opts);
+			expect(cmd).toContain("Don'\\''t touch the user'\\''s files");
+			expect(cmd).toContain("Read AGENTS.md");
+		});
+
+		test("with appendSystemPromptFile uses $(cat ...) expansion", () => {
+			const opts: SpawnOpts = {
+				model: "gpt-5-codex",
+				permissionMode: "bypass",
+				cwd: "/project",
+				env: {},
+				appendSystemPromptFile: "/project/.overstory/agent-defs/coordinator.md",
+			};
+			const cmd = runtime.buildSpawnCommand(opts);
+			expect(cmd).toContain("$(cat '/project/.overstory/agent-defs/coordinator.md')");
+			expect(cmd).toContain("Read AGENTS.md");
+		});
+
+		test("appendSystemPromptFile with single quotes in path", () => {
+			const opts: SpawnOpts = {
+				model: "gpt-5-codex",
+				permissionMode: "bypass",
+				cwd: "/project",
+				env: {},
+				appendSystemPromptFile: "/project/it's a path/agent.md",
+			};
+			const cmd = runtime.buildSpawnCommand(opts);
+			expect(cmd).toContain("$(cat '/project/it'\\''s a path/agent.md')");
+		});
+
+		test("appendSystemPromptFile suffix is single-quoted (prevents shell expansion)", () => {
+			const opts: SpawnOpts = {
+				model: "gpt-5-codex",
+				permissionMode: "bypass",
+				cwd: "/project",
+				env: {},
+				appendSystemPromptFile: "/project/agent.md",
+			};
+			const cmd = runtime.buildSpawnCommand(opts);
+			// The suffix text must be in single quotes, NOT double quotes.
+			// Double quotes would allow $, backticks, and " in the cat output
+			// to be interpreted by the shell.
+			expect(cmd).toContain("')\"' Read AGENTS.md");
+			expect(cmd).toEndWith("begin immediately.'");
+		});
+
+		test("appendSystemPromptFile takes precedence over appendSystemPrompt", () => {
+			const opts: SpawnOpts = {
+				model: "gpt-5-codex",
+				permissionMode: "bypass",
+				cwd: "/project",
+				env: {},
+				appendSystemPromptFile: "/project/.overstory/agent-defs/coordinator.md",
+				appendSystemPrompt: "This inline content should be ignored",
+			};
+			const cmd = runtime.buildSpawnCommand(opts);
+			expect(cmd).toContain("$(cat ");
+			expect(cmd).not.toContain("This inline content should be ignored");
+		});
+
+		test("without appendSystemPrompt uses default AGENTS.md prompt", () => {
+			const opts: SpawnOpts = {
+				model: "gpt-5-codex",
+				permissionMode: "bypass",
+				cwd: "/tmp/worktree",
+				env: {},
+			};
+			const cmd = runtime.buildSpawnCommand(opts);
+			expect(cmd).toBe(
+				"codex exec --full-auto --json --model gpt-5-codex 'Read AGENTS.md for your task assignment and begin immediately.'",
+			);
+		});
+
+		test("cwd and env are not embedded in command string", () => {
+			const opts: SpawnOpts = {
+				model: "gpt-5-codex",
+				permissionMode: "bypass",
+				cwd: "/some/specific/path",
+				env: { OPENAI_API_KEY: "sk-test-123" },
+			};
+			const cmd = runtime.buildSpawnCommand(opts);
+			expect(cmd).not.toContain("/some/specific/path");
+			expect(cmd).not.toContain("sk-test-123");
+			expect(cmd).not.toContain("OPENAI_API_KEY");
+		});
+
+		test("produces identical output for the same inputs (deterministic)", () => {
+			const opts: SpawnOpts = {
+				model: "gpt-5-codex",
+				permissionMode: "bypass",
+				cwd: "/tmp/worktree",
+				env: {},
+				appendSystemPrompt: "You are a builder.",
+			};
+			const cmd1 = runtime.buildSpawnCommand(opts);
+			const cmd2 = runtime.buildSpawnCommand(opts);
+			expect(cmd1).toBe(cmd2);
+		});
+
+		test("all model names pass through unchanged", () => {
+			for (const model of ["gpt-5-codex", "gpt-4o", "o3", "custom-model-v2"]) {
+				const opts: SpawnOpts = {
+					model,
+					permissionMode: "bypass",
+					cwd: "/tmp",
+					env: {},
+				};
+				const cmd = runtime.buildSpawnCommand(opts);
+				expect(cmd).toContain(`--model ${model}`);
+			}
+		});
+
+		test("systemPrompt field is ignored", () => {
+			const opts: SpawnOpts = {
+				model: "gpt-5-codex",
+				permissionMode: "bypass",
+				cwd: "/tmp",
+				env: {},
+				systemPrompt: "This should not appear",
+			};
+			const cmd = runtime.buildSpawnCommand(opts);
+			expect(cmd).not.toContain("This should not appear");
+		});
+	});
+
+	describe("buildPrintCommand", () => {
+		test("basic command without model", () => {
+			const argv = runtime.buildPrintCommand("Summarize this diff");
+			expect(argv).toEqual(["codex", "exec", "--full-auto", "--ephemeral", "Summarize this diff"]);
+		});
+
+		test("command with model override", () => {
+			const argv = runtime.buildPrintCommand("Classify this error", "gpt-5-codex");
+			expect(argv).toEqual([
+				"codex",
+				"exec",
+				"--full-auto",
+				"--ephemeral",
+				"--model",
+				"gpt-5-codex",
+				"Classify this error",
+			]);
+		});
+
+		test("model undefined omits --model flag", () => {
+			const argv = runtime.buildPrintCommand("Hello", undefined);
+			expect(argv).not.toContain("--model");
+		});
+
+		test("prompt is the last element (positional argument)", () => {
+			const prompt = "My test prompt";
+			const argv = runtime.buildPrintCommand(prompt, "gpt-5-codex");
+			expect(argv[argv.length - 1]).toBe(prompt);
+		});
+
+		test("without model, argv has exactly 5 elements", () => {
+			const argv = runtime.buildPrintCommand("prompt text");
+			expect(argv.length).toBe(5);
+		});
+
+		test("with model, argv has exactly 7 elements", () => {
+			const argv = runtime.buildPrintCommand("prompt text", "gpt-5-codex");
+			expect(argv.length).toBe(7);
+		});
+
+		test("does not include --json (print expects plain text stdout)", () => {
+			const argv = runtime.buildPrintCommand("Summarize");
+			expect(argv).not.toContain("--json");
+		});
+
+		test("includes --ephemeral (no session persistence for one-shot calls)", () => {
+			const argv = runtime.buildPrintCommand("Summarize");
+			expect(argv).toContain("--ephemeral");
+		});
+	});
+
+	describe("detectReady", () => {
+		test("returns ready for empty pane (headless — always ready)", () => {
+			const state = runtime.detectReady("");
+			expect(state).toEqual({ phase: "ready" });
+		});
+
+		test("returns ready for any pane content", () => {
+			const state = runtime.detectReady("Loading Codex...\nPlease wait");
+			expect(state).toEqual({ phase: "ready" });
+		});
+
+		test("returns ready for NDJSON output", () => {
+			const state = runtime.detectReady(
+				'{"type":"thread.started","thread_id":"abc"}\n{"type":"turn.started"}',
+			);
+			expect(state).toEqual({ phase: "ready" });
+		});
+
+		test("no dialog phase — Codex has no trust dialog", () => {
+			const state = runtime.detectReady("trust this folder");
+			expect(state.phase).not.toBe("dialog");
+			expect(state.phase).toBe("ready");
+		});
+	});
+
+	describe("requiresBeaconVerification", () => {
+		test("returns false (headless — no beacon needed)", () => {
+			expect(runtime.requiresBeaconVerification()).toBe(false);
+		});
+	});
+
+	describe("buildEnv", () => {
+		test("returns empty object when model has no env", () => {
+			const model: ResolvedModel = { model: "gpt-5-codex" };
+			const env = runtime.buildEnv(model);
+			expect(env).toEqual({});
+		});
+
+		test("returns model.env when present", () => {
+			const model: ResolvedModel = {
+				model: "gpt-5-codex",
+				env: { OPENAI_API_KEY: "sk-test-123", OPENAI_BASE_URL: "https://api.example.com" },
+			};
+			const env = runtime.buildEnv(model);
+			expect(env).toEqual({
+				OPENAI_API_KEY: "sk-test-123",
+				OPENAI_BASE_URL: "https://api.example.com",
+			});
+		});
+
+		test("returns empty object when model.env is undefined", () => {
+			const model: ResolvedModel = { model: "gpt-5-codex", env: undefined };
+			const env = runtime.buildEnv(model);
+			expect(env).toEqual({});
+		});
+
+		test("result is safe to spread", () => {
+			const model: ResolvedModel = { model: "gpt-5-codex" };
+			const env = runtime.buildEnv(model);
+			const combined = { ...env, OVERSTORY_AGENT_NAME: "builder-1" };
+			expect(combined).toEqual({ OVERSTORY_AGENT_NAME: "builder-1" });
+		});
+	});
+
+	describe("deployConfig", () => {
+		let tempDir: string;
+
+		beforeEach(async () => {
+			tempDir = await mkdtemp(join(tmpdir(), "overstory-codex-test-"));
+		});
+
+		afterEach(async () => {
+			await rm(tempDir, { recursive: true, force: true });
+		});
+
+		test("writes overlay to AGENTS.md (not .claude/CLAUDE.md)", async () => {
+			const worktreePath = join(tempDir, "worktree");
+
+			await runtime.deployConfig(
+				worktreePath,
+				{ content: "# Agent Overlay\nThis is the task specification." },
+				{ agentName: "test-builder", capability: "builder", worktreePath },
+			);
+
+			const agentsPath = join(worktreePath, "AGENTS.md");
+			const content = await Bun.file(agentsPath).text();
+			expect(content).toBe("# Agent Overlay\nThis is the task specification.");
+
+			// .claude/CLAUDE.md should NOT exist
+			const claudeMdPath = join(worktreePath, ".claude", "CLAUDE.md");
+			const claudeExists = await Bun.file(claudeMdPath).exists();
+			expect(claudeExists).toBe(false);
+		});
+
+		test("no hooks or guard extensions are deployed (OS sandbox)", async () => {
+			const worktreePath = join(tempDir, "worktree");
+
+			await runtime.deployConfig(
+				worktreePath,
+				{ content: "# Overlay" },
+				{ agentName: "test-builder", capability: "builder", worktreePath },
+			);
+
+			// No .claude/settings.local.json (Claude hooks)
+			const settingsPath = join(worktreePath, ".claude", "settings.local.json");
+			const settingsExists = await Bun.file(settingsPath).exists();
+			expect(settingsExists).toBe(false);
+
+			// No .pi/extensions/ (Pi guard extensions)
+			const piGuardPath = join(worktreePath, ".pi", "extensions", "overstory-guard.ts");
+			const piGuardExists = await Bun.file(piGuardPath).exists();
+			expect(piGuardExists).toBe(false);
+		});
+
+		test("no-op when overlay is undefined (Codex has no hooks to deploy)", async () => {
+			const worktreePath = join(tempDir, "worktree");
+
+			await runtime.deployConfig(worktreePath, undefined, {
+				agentName: "coordinator",
+				capability: "coordinator",
+				worktreePath,
+			});
+
+			// AGENTS.md should NOT exist
+			const agentsPath = join(worktreePath, "AGENTS.md");
+			const agentsExists = await Bun.file(agentsPath).exists();
+			expect(agentsExists).toBe(false);
+		});
+
+		test("overlay content is written verbatim", async () => {
+			const worktreePath = join(tempDir, "worktree");
+			const content = "# Task\n\n## Acceptance Criteria\n\n- [ ] Tests pass\n- [ ] Lint clean\n";
+
+			await runtime.deployConfig(
+				worktreePath,
+				{ content },
+				{ agentName: "builder-1", capability: "builder", worktreePath },
+			);
+
+			const agentsPath = join(worktreePath, "AGENTS.md");
+			const written = await Bun.file(agentsPath).text();
+			expect(written).toBe(content);
+		});
+
+		test("creates worktree directory if it does not exist", async () => {
+			const worktreePath = join(tempDir, "deep", "nested", "worktree");
+
+			await runtime.deployConfig(
+				worktreePath,
+				{ content: "# Overlay" },
+				{ agentName: "builder-1", capability: "builder", worktreePath },
+			);
+
+			const agentsPath = join(worktreePath, "AGENTS.md");
+			const exists = await Bun.file(agentsPath).exists();
+			expect(exists).toBe(true);
+		});
+
+		test("different capabilities produce the same output (no hook differentiation)", async () => {
+			const builderPath = join(tempDir, "builder-wt");
+			const scoutPath = join(tempDir, "scout-wt");
+
+			await runtime.deployConfig(
+				builderPath,
+				{ content: "# Builder" },
+				{ agentName: "test-builder", capability: "builder", worktreePath: builderPath },
+			);
+
+			await runtime.deployConfig(
+				scoutPath,
+				{ content: "# Scout" },
+				{ agentName: "test-scout", capability: "scout", worktreePath: scoutPath },
+			);
+
+			// Both should only have AGENTS.md with their respective content
+			const builderAgents = await Bun.file(join(builderPath, "AGENTS.md")).text();
+			const scoutAgents = await Bun.file(join(scoutPath, "AGENTS.md")).text();
+			expect(builderAgents).toBe("# Builder");
+			expect(scoutAgents).toBe("# Scout");
+		});
+	});
+
+	describe("parseTranscript", () => {
+		let tempDir: string;
+
+		beforeEach(async () => {
+			tempDir = await mkdtemp(join(tmpdir(), "overstory-codex-transcript-test-"));
+		});
+
+		afterEach(async () => {
+			await rm(tempDir, { recursive: true, force: true });
+		});
+
+		test("returns null for non-existent file", async () => {
+			const result = await runtime.parseTranscript(join(tempDir, "does-not-exist.jsonl"));
+			expect(result).toBeNull();
+		});
+
+		test("parses turn.completed event with usage.input_tokens/output_tokens", async () => {
+			const transcriptPath = join(tempDir, "session.jsonl");
+			const event = JSON.stringify({
+				type: "turn.completed",
+				usage: { input_tokens: 24763, output_tokens: 122 },
+			});
+			await Bun.write(transcriptPath, `${event}\n`);
+
+			const result = await runtime.parseTranscript(transcriptPath);
+			expect(result).not.toBeNull();
+			expect(result?.inputTokens).toBe(24763);
+			expect(result?.outputTokens).toBe(122);
+		});
+
+		test("aggregates multiple turn.completed events", async () => {
+			const transcriptPath = join(tempDir, "session.jsonl");
+			const turn1 = JSON.stringify({
+				type: "turn.completed",
+				usage: { input_tokens: 1000, output_tokens: 200 },
+			});
+			const turn2 = JSON.stringify({
+				type: "turn.completed",
+				usage: { input_tokens: 2000, output_tokens: 300 },
+			});
+			await Bun.write(transcriptPath, `${turn1}\n${turn2}\n`);
+
+			const result = await runtime.parseTranscript(transcriptPath);
+			expect(result).not.toBeNull();
+			expect(result?.inputTokens).toBe(3000);
+			expect(result?.outputTokens).toBe(500);
+		});
+
+		test("captures model from event with model field", async () => {
+			const transcriptPath = join(tempDir, "session.jsonl");
+			const started = JSON.stringify({
+				type: "thread.started",
+				model: "gpt-5-codex",
+				thread_id: "abc",
+			});
+			const turn = JSON.stringify({
+				type: "turn.completed",
+				usage: { input_tokens: 100, output_tokens: 50 },
+			});
+			await Bun.write(transcriptPath, `${started}\n${turn}\n`);
+
+			const result = await runtime.parseTranscript(transcriptPath);
+			expect(result?.model).toBe("gpt-5-codex");
+		});
+
+		test("last event with model field wins", async () => {
+			const transcriptPath = join(tempDir, "session.jsonl");
+			const event1 = JSON.stringify({ type: "thread.started", model: "gpt-4o" });
+			const event2 = JSON.stringify({
+				type: "turn.completed",
+				model: "gpt-5-codex",
+				usage: { input_tokens: 10, output_tokens: 5 },
+			});
+			await Bun.write(transcriptPath, `${event1}\n${event2}\n`);
+
+			const result = await runtime.parseTranscript(transcriptPath);
+			expect(result?.model).toBe("gpt-5-codex");
+		});
+
+		test("defaults model to empty string when no model field in events", async () => {
+			const transcriptPath = join(tempDir, "session.jsonl");
+			const event = JSON.stringify({
+				type: "turn.completed",
+				usage: { input_tokens: 10, output_tokens: 5 },
+			});
+			await Bun.write(transcriptPath, `${event}\n`);
+
+			const result = await runtime.parseTranscript(transcriptPath);
+			expect(result?.model).toBe("");
+		});
+
+		test("handles turn.completed with cached_input_tokens", async () => {
+			const transcriptPath = join(tempDir, "session.jsonl");
+			const event = JSON.stringify({
+				type: "turn.completed",
+				usage: {
+					input_tokens: 24763,
+					cached_input_tokens: 24448,
+					output_tokens: 122,
+				},
+			});
+			await Bun.write(transcriptPath, `${event}\n`);
+
+			const result = await runtime.parseTranscript(transcriptPath);
+			// cached_input_tokens is metadata — we only count input_tokens
+			expect(result?.inputTokens).toBe(24763);
+			expect(result?.outputTokens).toBe(122);
+		});
+
+		test("skips non-turn.completed events for token counting", async () => {
+			const transcriptPath = join(tempDir, "session.jsonl");
+			const threadStarted = JSON.stringify({
+				type: "thread.started",
+				thread_id: "abc",
+			});
+			const itemCreated = JSON.stringify({
+				type: "item.created",
+				item: { type: "message", role: "assistant" },
+			});
+			const turnCompleted = JSON.stringify({
+				type: "turn.completed",
+				usage: { input_tokens: 100, output_tokens: 50 },
+			});
+			await Bun.write(transcriptPath, `${threadStarted}\n${itemCreated}\n${turnCompleted}\n`);
+
+			const result = await runtime.parseTranscript(transcriptPath);
+			expect(result?.inputTokens).toBe(100);
+			expect(result?.outputTokens).toBe(50);
+		});
+
+		test("returns zero counts for file with no turn.completed events", async () => {
+			const transcriptPath = join(tempDir, "session.jsonl");
+			const event = JSON.stringify({
+				type: "thread.started",
+				thread_id: "abc",
+			});
+			await Bun.write(transcriptPath, `${event}\n`);
+
+			const result = await runtime.parseTranscript(transcriptPath);
+			expect(result).not.toBeNull();
+			expect(result?.inputTokens).toBe(0);
+			expect(result?.outputTokens).toBe(0);
+		});
+
+		test("skips malformed lines and parses valid ones", async () => {
+			const transcriptPath = join(tempDir, "mixed.jsonl");
+			const bad = "not json at all";
+			const good = JSON.stringify({
+				type: "turn.completed",
+				usage: { input_tokens: 42, output_tokens: 7 },
+			});
+			await Bun.write(transcriptPath, `${bad}\n${good}\n`);
+
+			const result = await runtime.parseTranscript(transcriptPath);
+			expect(result?.inputTokens).toBe(42);
+			expect(result?.outputTokens).toBe(7);
+		});
+
+		test("handles empty file (returns zero counts)", async () => {
+			const transcriptPath = join(tempDir, "empty.jsonl");
+			await Bun.write(transcriptPath, "");
+
+			const result = await runtime.parseTranscript(transcriptPath);
+			expect(result).not.toBeNull();
+			expect(result?.inputTokens).toBe(0);
+			expect(result?.outputTokens).toBe(0);
+		});
+
+		test("handles turn.completed without usage field", async () => {
+			const transcriptPath = join(tempDir, "session.jsonl");
+			const event = JSON.stringify({ type: "turn.completed" });
+			await Bun.write(transcriptPath, `${event}\n`);
+
+			const result = await runtime.parseTranscript(transcriptPath);
+			expect(result).not.toBeNull();
+			expect(result?.inputTokens).toBe(0);
+			expect(result?.outputTokens).toBe(0);
+		});
+
+		test("does not count Claude-style assistant events", async () => {
+			const transcriptPath = join(tempDir, "session.jsonl");
+			// Claude-style entries should NOT be counted
+			const claudeStyleEntry = JSON.stringify({
+				type: "assistant",
+				message: { usage: { input_tokens: 999, output_tokens: 999 } },
+			});
+			const codexEntry = JSON.stringify({
+				type: "turn.completed",
+				usage: { input_tokens: 10, output_tokens: 5 },
+			});
+			await Bun.write(transcriptPath, `${claudeStyleEntry}\n${codexEntry}\n`);
+
+			const result = await runtime.parseTranscript(transcriptPath);
+			expect(result?.inputTokens).toBe(10);
+			expect(result?.outputTokens).toBe(5);
+		});
+
+		test("does not count Pi-style message_end events", async () => {
+			const transcriptPath = join(tempDir, "session.jsonl");
+			// Pi-style entries should NOT be counted
+			const piStyleEntry = JSON.stringify({
+				type: "message_end",
+				inputTokens: 999,
+				outputTokens: 999,
+			});
+			const codexEntry = JSON.stringify({
+				type: "turn.completed",
+				usage: { input_tokens: 10, output_tokens: 5 },
+			});
+			await Bun.write(transcriptPath, `${piStyleEntry}\n${codexEntry}\n`);
+
+			const result = await runtime.parseTranscript(transcriptPath);
+			expect(result?.inputTokens).toBe(10);
+			expect(result?.outputTokens).toBe(5);
+		});
+	});
+});
+
+describe("CodexRuntime integration: spawn command structure", () => {
+	const runtime = new CodexRuntime();
+
+	test("sling-style spawn: bypass mode, no system prompt", () => {
+		const cmd = runtime.buildSpawnCommand({
+			model: "gpt-5-codex",
+			permissionMode: "bypass",
+			cwd: "/project/.overstory/worktrees/builder-1",
+			env: { OVERSTORY_AGENT_NAME: "builder-1" },
+		});
+		expect(cmd).toBe(
+			"codex exec --full-auto --json --model gpt-5-codex 'Read AGENTS.md for your task assignment and begin immediately.'",
+		);
+	});
+
+	test("coordinator-style spawn: bypass mode with appendSystemPrompt", () => {
+		const baseDefinition = "# Coordinator\nYou are the coordinator agent.";
+		const cmd = runtime.buildSpawnCommand({
+			model: "gpt-5-codex",
+			permissionMode: "bypass",
+			cwd: "/project",
+			appendSystemPrompt: baseDefinition,
+			env: { OVERSTORY_AGENT_NAME: "coordinator" },
+		});
+		expect(cmd).toContain("codex exec --full-auto --json --model gpt-5-codex");
+		expect(cmd).toContain("# Coordinator");
+		expect(cmd).toContain("You are the coordinator agent.");
+		expect(cmd).toContain("Read AGENTS.md");
+	});
+
+	test("coordinator-style spawn: with appendSystemPromptFile", () => {
+		const cmd = runtime.buildSpawnCommand({
+			model: "gpt-5-codex",
+			permissionMode: "bypass",
+			cwd: "/project",
+			appendSystemPromptFile: "/project/.overstory/agent-defs/coordinator.md",
+			env: { OVERSTORY_AGENT_NAME: "coordinator" },
+		});
+		expect(cmd).toContain("codex exec --full-auto --json --model gpt-5-codex");
+		expect(cmd).toContain("$(cat '/project/.overstory/agent-defs/coordinator.md')");
+		expect(cmd).toContain("Read AGENTS.md");
+	});
+});
+
+describe("CodexRuntime integration: buildEnv matches provider pattern", () => {
+	const runtime = new CodexRuntime();
+
+	test("OpenAI model: passes env through", () => {
+		const model: ResolvedModel = {
+			model: "gpt-5-codex",
+			env: { OPENAI_API_KEY: "sk-test-123" },
+		};
+		const env = runtime.buildEnv(model);
+		expect(env).toEqual({ OPENAI_API_KEY: "sk-test-123" });
+	});
+
+	test("custom provider: passes env through", () => {
+		const model: ResolvedModel = {
+			model: "custom-model",
+			env: { OPENAI_API_KEY: "sk-test", OPENAI_BASE_URL: "https://custom.api/v1" },
+		};
+		const env = runtime.buildEnv(model);
+		expect(env).toEqual({
+			OPENAI_API_KEY: "sk-test",
+			OPENAI_BASE_URL: "https://custom.api/v1",
+		});
+	});
+
+	test("model without env: returns empty object (safe to spread)", () => {
+		const model: ResolvedModel = { model: "gpt-5-codex" };
+		const env = runtime.buildEnv(model);
+		expect(env).toEqual({});
+		const combined = { ...env, OVERSTORY_AGENT_NAME: "builder-1" };
+		expect(combined).toEqual({ OVERSTORY_AGENT_NAME: "builder-1" });
+	});
+});
+
+describe("CodexRuntime integration: registry resolves 'codex'", () => {
+	test("getRuntime('codex') returns CodexRuntime", async () => {
+		const { getRuntime } = await import("./registry.ts");
+		const rt = getRuntime("codex");
+		expect(rt).toBeInstanceOf(CodexRuntime);
+		expect(rt.id).toBe("codex");
+		expect(rt.instructionPath).toBe("AGENTS.md");
+	});
+});

--- a/src/runtimes/codex.ts
+++ b/src/runtimes/codex.ts
@@ -1,0 +1,228 @@
+// Codex runtime adapter for overstory's AgentRuntime interface.
+// Implements the AgentRuntime contract for the OpenAI `codex` CLI.
+//
+// Key differences from Claude/Pi adapters:
+// - Headless: `codex exec` exits on completion (no persistent TUI)
+// - Instruction file: AGENTS.md (not .claude/CLAUDE.md)
+// - No hooks: Codex uses OS-level sandbox (Seatbelt/Landlock)
+// - Events: NDJSON stream to stdout (parsed for token usage)
+
+import { mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type { ResolvedModel } from "../types.ts";
+import type {
+	AgentRuntime,
+	HooksDef,
+	OverlayContent,
+	ReadyState,
+	SpawnOpts,
+	TranscriptSummary,
+} from "./types.ts";
+
+/**
+ * Codex runtime adapter.
+ *
+ * Implements AgentRuntime for the OpenAI `codex` CLI. Codex agents run in
+ * headless mode (`codex exec`) — they process a task and exit, rather than
+ * maintaining a persistent TUI like Claude Code or Pi.
+ *
+ * Security is enforced via Codex's OS-level sandbox (Seatbelt on macOS,
+ * Landlock on Linux) rather than hook-based guards. The `--full-auto` flag
+ * enables `workspace-write` sandbox + automatic approvals.
+ *
+ * Instructions are delivered via `AGENTS.md` (Codex's native convention),
+ * not `.claude/CLAUDE.md`.
+ */
+export class CodexRuntime implements AgentRuntime {
+	/** Unique identifier for this runtime. */
+	readonly id = "codex";
+
+	/** Relative path to the instruction file within a worktree. */
+	readonly instructionPath = "AGENTS.md";
+
+	/**
+	 * Build the shell command string to spawn a Codex agent in a tmux pane.
+	 *
+	 * Uses `codex exec` (headless mode) with `--full-auto` for workspace-write
+	 * sandbox + automatic approvals, and `--json` for NDJSON event output.
+	 *
+	 * The prompt directs the agent to read AGENTS.md for its full instructions.
+	 * If `appendSystemPrompt` or `appendSystemPromptFile` is provided, the
+	 * content is prepended to the prompt (Codex has no --append-system-prompt
+	 * flag — all context goes through the exec prompt or AGENTS.md).
+	 *
+	 * @param opts - Spawn options (model, appendSystemPrompt; permissionMode is accepted but
+	 *   not mapped — Codex enforces security via OS sandbox, not permission flags)
+	 * @returns Shell command string suitable for tmux new-session -c
+	 */
+	buildSpawnCommand(opts: SpawnOpts): string {
+		let cmd = `codex exec --full-auto --json --model ${opts.model}`;
+
+		if (opts.appendSystemPromptFile) {
+			// Read role definition from file at shell expansion time — avoids tmux
+			// IPC message size limits. Append the "read AGENTS.md" instruction.
+			const escaped = opts.appendSystemPromptFile.replace(/'/g, "'\\''");
+			cmd += ` "$(cat '${escaped}')"' Read AGENTS.md for your task assignment and begin immediately.'`;
+		} else if (opts.appendSystemPrompt) {
+			// Inline role definition + instruction to read AGENTS.md.
+			const prompt = `${opts.appendSystemPrompt}\n\nRead AGENTS.md for your task assignment and begin immediately.`;
+			const escaped = prompt.replace(/'/g, "'\\''");
+			cmd += ` '${escaped}'`;
+		} else {
+			cmd += ` 'Read AGENTS.md for your task assignment and begin immediately.'`;
+		}
+
+		return cmd;
+	}
+
+	/**
+	 * Build the argv array for a headless one-shot Codex invocation.
+	 *
+	 * Returns an argv array suitable for `Bun.spawn()`. Uses `codex exec`
+	 * with `--full-auto` and `--ephemeral` (no session persistence).
+	 * Without `--json`, stdout contains the plain text final message.
+	 *
+	 * Used by merge/resolver.ts (AI-assisted conflict resolution) and
+	 * watchdog/triage.ts (AI-assisted failure classification).
+	 *
+	 * @param prompt - The prompt to pass as the exec argument
+	 * @param model - Optional model override
+	 * @returns Argv array for Bun.spawn
+	 */
+	buildPrintCommand(prompt: string, model?: string): string[] {
+		const cmd = ["codex", "exec", "--full-auto", "--ephemeral"];
+		if (model !== undefined) {
+			cmd.push("--model", model);
+		}
+		cmd.push(prompt);
+		return cmd;
+	}
+
+	/**
+	 * Deploy per-agent instructions to a worktree.
+	 *
+	 * Writes the overlay to `AGENTS.md` in the worktree root (Codex's native
+	 * instruction file convention). Unlike Claude/Pi adapters, no hooks or
+	 * guard extensions are deployed — Codex enforces security boundaries via
+	 * its OS-level sandbox (Seatbelt on macOS, Landlock on Linux).
+	 *
+	 * When overlay is undefined (hooks-only deployment for coordinator/supervisor/monitor),
+	 * this is a no-op since Codex has no hook system to deploy.
+	 *
+	 * @param worktreePath - Absolute path to the agent's git worktree
+	 * @param overlay - Overlay content to write as AGENTS.md, or undefined for no-op
+	 * @param _hooks - Hook definition (unused — Codex uses OS sandbox, not hooks)
+	 */
+	async deployConfig(
+		worktreePath: string,
+		overlay: OverlayContent | undefined,
+		_hooks: HooksDef,
+	): Promise<void> {
+		if (!overlay) return;
+
+		const agentsPath = join(worktreePath, this.instructionPath);
+		// Ensure parent directory exists (AGENTS.md is in the worktree root,
+		// but the worktree dir itself might not exist yet).
+		await mkdir(dirname(agentsPath), { recursive: true });
+		await Bun.write(agentsPath, overlay.content);
+	}
+
+	/**
+	 * Codex exec is headless — always ready.
+	 *
+	 * Unlike Claude Code and Pi which maintain persistent TUI sessions,
+	 * `codex exec` starts processing immediately and exits on completion.
+	 * No TUI readiness detection is needed.
+	 *
+	 * @param _paneContent - Captured tmux pane content (unused)
+	 * @returns Always `{ phase: "ready" }`
+	 */
+	detectReady(_paneContent: string): ReadyState {
+		return { phase: "ready" };
+	}
+
+	/**
+	 * Codex does not require beacon verification/resend.
+	 *
+	 * The beacon verification loop exists because Claude Code's TUI sometimes
+	 * swallows the initial Enter during late initialization. Codex exec is
+	 * headless — it processes the prompt immediately with no TUI startup delay.
+	 */
+	requiresBeaconVerification(): boolean {
+		return false;
+	}
+
+	/**
+	 * Parse a Codex NDJSON transcript file into normalized token usage.
+	 *
+	 * Codex NDJSON format (from `--json` flag) differs from Claude/Pi:
+	 * - Token counts are in `turn.completed` events with
+	 *   `usage.input_tokens` and `usage.output_tokens`
+	 * - Model identity may appear in `thread.started` events or item metadata
+	 *
+	 * Returns null if the file does not exist or cannot be parsed.
+	 *
+	 * @param path - Absolute path to the Codex NDJSON transcript file
+	 * @returns Aggregated token usage, or null if unavailable
+	 */
+	async parseTranscript(path: string): Promise<TranscriptSummary | null> {
+		const file = Bun.file(path);
+		if (!(await file.exists())) {
+			return null;
+		}
+
+		try {
+			const text = await file.text();
+			const lines = text.split("\n").filter((l) => l.trim().length > 0);
+
+			let inputTokens = 0;
+			let outputTokens = 0;
+			let model = "";
+
+			for (const line of lines) {
+				let event: Record<string, unknown>;
+				try {
+					event = JSON.parse(line) as Record<string, unknown>;
+				} catch {
+					// Skip malformed lines — partial writes during capture.
+					continue;
+				}
+
+				if (event.type === "turn.completed") {
+					const usage = event.usage as Record<string, number | undefined> | undefined;
+					if (usage) {
+						if (typeof usage.input_tokens === "number") {
+							inputTokens += usage.input_tokens;
+						}
+						if (typeof usage.output_tokens === "number") {
+							outputTokens += usage.output_tokens;
+						}
+					}
+				}
+
+				// Capture model from any event that carries it.
+				if (typeof event.model === "string") {
+					model = event.model;
+				}
+			}
+
+			return { inputTokens, outputTokens, model };
+		} catch {
+			return null;
+		}
+	}
+
+	/**
+	 * Build runtime-specific environment variables for model/provider routing.
+	 *
+	 * Returns the provider environment variables from the resolved model.
+	 * For OpenAI native: may include OPENAI_API_KEY, OPENAI_BASE_URL.
+	 * For gateway providers: may include gateway-specific auth and routing vars.
+	 *
+	 * @param model - Resolved model with optional provider env vars
+	 * @returns Environment variable map (may be empty)
+	 */
+	buildEnv(model: ResolvedModel): Record<string, string> {
+		return model.env ?? {};
+	}
+}

--- a/src/runtimes/pi.test.ts
+++ b/src/runtimes/pi.test.ts
@@ -642,7 +642,7 @@ describe("PiRuntime integration: registry resolves 'pi'", () => {
 
 	test("getRuntime rejects truly unknown runtimes", async () => {
 		const { getRuntime } = await import("./registry.ts");
-		expect(() => getRuntime("codex")).toThrow('Unknown runtime: "codex"');
 		expect(() => getRuntime("opencode")).toThrow('Unknown runtime: "opencode"');
+		expect(() => getRuntime("aider")).toThrow('Unknown runtime: "aider"');
 	});
 });

--- a/src/runtimes/registry.test.ts
+++ b/src/runtimes/registry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { OverstoryConfig } from "../types.ts";
 import { ClaudeRuntime } from "./claude.ts";
+import { CodexRuntime } from "./codex.ts";
 import { CopilotRuntime } from "./copilot.ts";
 import { PiRuntime } from "./pi.ts";
 import { getRuntime } from "./registry.ts";
@@ -20,7 +21,7 @@ describe("getRuntime", () => {
 
 	it("throws with a helpful message for an unknown runtime", () => {
 		expect(() => getRuntime("unknown-runtime")).toThrow(
-			'Unknown runtime: "unknown-runtime". Available: claude',
+			'Unknown runtime: "unknown-runtime". Available: claude, codex, pi, copilot',
 		);
 	});
 
@@ -39,12 +40,11 @@ describe("getRuntime", () => {
 		expect(runtime).toBeInstanceOf(ClaudeRuntime);
 	});
 
-	it("throws for unknown runtime even when config default is set", () => {
+	it("resolves codex runtime from config default", () => {
 		const config = { runtime: { default: "codex" } } as OverstoryConfig;
-		// No name arg — falls back to config default "codex" which is unknown.
-		expect(() => getRuntime(undefined, config)).toThrow(
-			'Unknown runtime: "codex". Available: claude',
-		);
+		const runtime = getRuntime(undefined, config);
+		expect(runtime).toBeInstanceOf(CodexRuntime);
+		expect(runtime.id).toBe("codex");
 	});
 
 	it("returns a new instance on each call (factory pattern)", () => {

--- a/src/runtimes/registry.ts
+++ b/src/runtimes/registry.ts
@@ -3,6 +3,7 @@
 
 import type { OverstoryConfig } from "../types.ts";
 import { ClaudeRuntime } from "./claude.ts";
+import { CodexRuntime } from "./codex.ts";
 import { CopilotRuntime } from "./copilot.ts";
 import { PiRuntime } from "./pi.ts";
 import type { AgentRuntime } from "./types.ts";
@@ -10,6 +11,7 @@ import type { AgentRuntime } from "./types.ts";
 /** Registry of config-independent runtime adapters (name → factory). */
 const runtimes = new Map<string, () => AgentRuntime>([
 	["claude", () => new ClaudeRuntime()],
+	["codex", () => new CodexRuntime()],
 	["pi", () => new PiRuntime()],
 	["copilot", () => new CopilotRuntime()],
 ]);


### PR DESCRIPTION
## Summary

Implements the `AgentRuntime` interface for OpenAI's Codex CLI, tracked in #43.

- **`src/runtimes/codex.ts`** (~200 lines) — full adapter implementation
- **`src/runtimes/codex.test.ts`** (~620 lines) — comprehensive test coverage
- **`src/runtimes/registry.ts`** — registers `codex` in the runtime map
- Updated existing tests in `claude.test.ts`, `pi.test.ts`, `registry.test.ts` to reflect `codex` being a known runtime

### Key design decisions

- **Headless exec mode**: `codex exec --full-auto --json` — exits on completion, no persistent TUI
- **Instruction file**: writes overlay to `AGENTS.md` (Codex convention), not `.claude/CLAUDE.md`
- **No hooks**: `deployConfig()` skips hook/guard deployment — Codex uses OS-level sandbox (Seatbelt/Landlock)
- **`detectReady()`**: always returns `{ phase: "ready" }` (headless — no TUI readiness detection needed)
- **`requiresBeaconVerification()`**: returns `false` (no TUI startup delay to work around)
- **`parseTranscript()`**: parses `turn.completed` NDJSON events for `usage.input_tokens` / `usage.output_tokens`
- **`buildPrintCommand()`**: uses `codex exec --full-auto --ephemeral` (no `--json`, plain text stdout for resolver/triage)
- **`appendSystemPrompt`** handling: prepended to the exec prompt (Codex has no `--append-system-prompt` flag)

### What's NOT in this PR

Per the open questions in #43, these need investigation with a live Codex install:
- Exact TUI readiness strings (if interactive mode is later supported)
- Transcript log file location and format details
- `SessionStore` schema changes for exit-on-completion lifecycle
- Watchdog handling for distinguishing "exited because done" vs "crashed"

These are runtime-specific integration concerns best validated with a real Codex environment.

## Test plan

- [x] 245 runtime tests pass (0 failures)
- [x] `npx biome check` — lint and format clean
- [x] `npx tsc --noEmit` — type check clean
- [x] Full test suite: 2638 pass, 21 fail (all pre-existing `createMulchClient` failures unrelated to this PR — verified same failures on `main`)

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)