### PR TITLE
fix: use alternate screen buffer for dashboard TUI

### DIFF
--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -1106,6 +1106,12 @@ async function executeDashboard(opts: DashboardOpts): Promise<void> {
 				config.runtime,
 			);
 			lastGoodData = data;
+			// If recovering from an error, clear the stale error line at the bottom
+			if (lastErrorMsg !== null) {
+				const w = process.stdout.columns ?? 100;
+				const h = process.stdout.rows ?? 30;
+				process.stdout.write(`${CURSOR.cursorTo(h, 1)}${" ".repeat(w)}`);
+			}
 			lastErrorMsg = null;
 			renderDashboard(data, interval, isFirstRender);
 			isFirstRender = false;


### PR DESCRIPTION
## Summary
- Switch dashboard from `\x1b[2J` (clear screen) to the standard alternate screen buffer (`\x1b[?1049h`/`\x1b[?1049l`) used by htop/vim/less
- Use home-cursor redraws after the first render instead of clearing on every tick
- Enable raw stdin mode to prevent mouse scroll / arrow key escape sequences from being echoed as garbage text
- Add `q` to quit as a standard TUI convention alongside Ctrl+C
- Restore original terminal content on exit

Fixes the issue where Warp terminal appends new output blocks on each refresh instead of redrawing in-place.

## Test plan
- [x] Run `ov dashboard` in Warp — verify it redraws in-place without scrolling
- [x] Mouse scroll — verify no garbage `^[OA`/`^[OB` text appears
- [x] Press `q` — verify dashboard exits cleanly
- [x] Press Ctrl+C — verify dashboard exits cleanly
- [x] Verify original terminal content is restored after exit
- [x] Run in a standard terminal (iTerm2, Terminal.app) — verify same behavior