### PR TITLE
feat: isolate project tmux sessions

### DIFF
--- a/src/commands/completions.test.ts
+++ b/src/commands/completions.test.ts
@@ -2,7 +2,7 @@
  * Tests for shell completion generation.
  */
 
-import { describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import {
 	COMMANDS,
 	completionsCommand,
@@ -11,46 +11,65 @@ import {
 	generateZsh,
 } from "./completions.ts";
 
+const EXPECTED_COMMAND_NAMES = [
+	"agents",
+	"init",
+	"sling",
+	"prime",
+	"stop",
+	"sessions",
+	"status",
+	"dashboard",
+	"inspect",
+	"merge",
+	"nudge",
+	"clean",
+	"doctor",
+	"log",
+	"logs",
+	"watch",
+	"trace",
+	"errors",
+	"feed",
+	"replay",
+	"costs",
+	"metrics",
+	"spec",
+	"coordinator",
+	"supervisor",
+	"hooks",
+	"monitor",
+	"mail",
+	"group",
+	"worktree",
+	"run",
+	"ecosystem",
+	"upgrade",
+	"completions",
+] satisfies string[];
+
+let originalExitCode: number | undefined;
+
+beforeEach(() => {
+	originalExitCode = process.exitCode as number | undefined;
+	process.exitCode = 0;
+});
+
+afterEach(() => {
+	process.exitCode = originalExitCode ?? 0;
+});
+
 describe("COMMANDS array", () => {
-	it("should have exactly 33 commands", () => {
-		expect(COMMANDS).toHaveLength(33);
+	it("should match the expected top-level commands", () => {
+		expect(COMMANDS).toHaveLength(EXPECTED_COMMAND_NAMES.length);
+		expect(COMMANDS.map((c) => c.name)).toEqual(EXPECTED_COMMAND_NAMES);
 	});
 
 	it("should include all expected command names", () => {
 		const names = COMMANDS.map((c) => c.name);
-		expect(names).toContain("agents");
-		expect(names).toContain("init");
-		expect(names).toContain("sling");
-		expect(names).toContain("prime");
-		expect(names).toContain("status");
-		expect(names).toContain("dashboard");
-		expect(names).toContain("inspect");
-		expect(names).toContain("merge");
-		expect(names).toContain("nudge");
-		expect(names).toContain("clean");
-		expect(names).toContain("doctor");
-		expect(names).toContain("log");
-		expect(names).toContain("watch");
-		expect(names).toContain("trace");
-		expect(names).toContain("errors");
-		expect(names).toContain("replay");
-		expect(names).toContain("costs");
-		expect(names).toContain("metrics");
-		expect(names).toContain("spec");
-		expect(names).toContain("coordinator");
-		expect(names).toContain("supervisor");
-		expect(names).toContain("hooks");
-		expect(names).toContain("monitor");
-		expect(names).toContain("mail");
-		expect(names).toContain("group");
-		expect(names).toContain("worktree");
-		expect(names).toContain("run");
-		expect(names).toContain("feed");
-		expect(names).toContain("logs");
-		expect(names).toContain("stop");
-		expect(names).toContain("ecosystem");
-		expect(names).toContain("upgrade");
-		expect(names).toContain("completions");
+		for (const name of EXPECTED_COMMAND_NAMES) {
+			expect(names).toContain(name);
+		}
 	});
 });
 
@@ -62,7 +81,7 @@ describe("generateBash", () => {
 		expect(script).toContain("_init_completion");
 	});
 
-	it("should include all 33 command names", () => {
+	it("should include all command names", () => {
 		const script = generateBash();
 		for (const cmd of COMMANDS) {
 			expect(script).toContain(cmd.name);
@@ -96,7 +115,7 @@ describe("generateZsh", () => {
 		expect(script).toContain("_arguments");
 	});
 
-	it("should include all 33 command names", () => {
+	it("should include all command names", () => {
 		const script = generateZsh();
 		for (const cmd of COMMANDS) {
 			expect(script).toContain(cmd.name);
@@ -126,7 +145,7 @@ describe("generateFish", () => {
 		expect(script).toContain("__fish_use_subcommand");
 	});
 
-	it("should include all 33 command names", () => {
+	it("should include all command names", () => {
 		const script = generateFish();
 		for (const cmd of COMMANDS) {
 			expect(script).toContain(cmd.name);

--- a/src/commands/completions.test.ts
+++ b/src/commands/completions.test.ts
@@ -20,6 +20,7 @@ const EXPECTED_COMMAND_NAMES = [
 	"sessions",
 	"status",
 	"dashboard",
+	"discover",
 	"inspect",
 	"merge",
 	"nudge",
@@ -44,6 +45,7 @@ const EXPECTED_COMMAND_NAMES = [
 	"worktree",
 	"run",
 	"ecosystem",
+	"update",
 	"upgrade",
 	"completions",
 ] satisfies string[];

--- a/src/commands/completions.ts
+++ b/src/commands/completions.ts
@@ -116,6 +116,45 @@ export const COMMANDS: readonly CommandDef[] = [
 		],
 	},
 	{
+		name: "sessions",
+		desc: "Manage isolated tmux sessions",
+		subcommands: [
+			{
+				name: "list",
+				desc: "List overstory-managed tmux sessions",
+				flags: [
+					{ name: "--all", desc: "Include completed and zombie sessions" },
+					{ name: "--json", desc: "JSON output" },
+					{ name: "--help", desc: "Show help" },
+				],
+			},
+			{
+				name: "attach",
+				desc: "Attach to an active tmux session",
+				flags: [
+					{ name: "--json", desc: "JSON output" },
+					{ name: "--help", desc: "Show help" },
+				],
+			},
+			{
+				name: "kill",
+				desc: "Kill an isolated tmux session",
+				flags: [
+					{ name: "--json", desc: "JSON output" },
+					{ name: "--help", desc: "Show help" },
+				],
+			},
+			{
+				name: "current",
+				desc: "Print the current tmux session name",
+				flags: [
+					{ name: "--json", desc: "JSON output" },
+					{ name: "--help", desc: "Show help" },
+				],
+			},
+		],
+	},
+	{
 		name: "status",
 		desc: "Show all active agents and project state",
 		flags: [
@@ -660,7 +699,7 @@ export function generateBash(): string {
 		"  local cur prev words cword",
 		"  _init_completion || return",
 		"",
-		"  local commands='agents init sling prime stop status dashboard inspect merge nudge clean doctor log logs watch trace errors feed replay costs metrics spec coordinator supervisor hooks monitor mail group worktree run ecosystem upgrade completions'",
+		"  local commands='agents init sling prime stop status sessions dashboard inspect merge nudge clean doctor log logs watch trace errors feed replay costs metrics spec coordinator supervisor hooks monitor mail group worktree run ecosystem upgrade completions'",
 		"",
 		"  # Top-level completion",
 		"  if [[ $cword -eq 1 ]]; then",

--- a/src/commands/completions.ts
+++ b/src/commands/completions.ts
@@ -117,7 +117,7 @@ export const COMMANDS: readonly CommandDef[] = [
 	},
 	{
 		name: "sessions",
-		desc: "Manage isolated tmux sessions",
+		desc: "Manage isolated overstory tmux sessions",
 		subcommands: [
 			{
 				name: "list",
@@ -724,7 +724,7 @@ export function generateBash(): string {
 		"  local cur prev words cword",
 		"  _init_completion || return",
 		"",
-		"  local commands='agents init sling prime stop status sessions dashboard inspect merge nudge clean doctor log logs watch trace errors feed replay costs metrics spec coordinator supervisor hooks monitor mail group worktree run ecosystem upgrade completions'",
+		"  local commands='agents init sling prime stop status sessions dashboard inspect merge nudge clean doctor log logs watch trace errors feed replay costs metrics spec coordinator supervisor hooks monitor mail group worktree run ecosystem update upgrade completions'",
 		"",
 		"  # Top-level completion",
 		"  if [[ $cword -eq 1 ]]; then",

--- a/src/commands/completions.ts
+++ b/src/commands/completions.ts
@@ -176,6 +176,19 @@ export const COMMANDS: readonly CommandDef[] = [
 		],
 	},
 	{
+		name: "discover",
+		desc: "Discover a brownfield codebase via coordinator-driven scout swarm",
+		flags: [
+			{ name: "--skip", desc: "Skip categories (comma-separated)", takesValue: true },
+			{ name: "--name", desc: "Coordinator agent name", takesValue: true },
+			{ name: "--attach", desc: "Always attach to tmux session after start" },
+			{ name: "--no-attach", desc: "Never attach to tmux session after start" },
+			{ name: "--watchdog", desc: "Auto-start watchdog daemon with coordinator" },
+			{ name: "--json", desc: "JSON output" },
+			{ name: "--help", desc: "Show help" },
+		],
+	},
+	{
 		name: "inspect",
 		desc: "Deep inspection of a single agent",
 		flags: [
@@ -668,6 +681,18 @@ export const COMMANDS: readonly CommandDef[] = [
 		name: "ecosystem",
 		desc: "Show a summary dashboard of all installed os-eco tools",
 		flags: [
+			{ name: "--json", desc: "JSON output" },
+			{ name: "--help", desc: "Show help" },
+		],
+	},
+	{
+		name: "update",
+		desc: "Refresh .overstory/ managed files from the installed package",
+		flags: [
+			{ name: "--agents", desc: "Refresh agent definition files only" },
+			{ name: "--manifest", desc: "Refresh agent-manifest.json only" },
+			{ name: "--hooks", desc: "Refresh hooks.json only" },
+			{ name: "--dry-run", desc: "Show what would change without writing" },
 			{ name: "--json", desc: "JSON output" },
 			{ name: "--help", desc: "Show help" },
 		],

--- a/src/commands/coordinator.ts
+++ b/src/commands/coordinator.ts
@@ -31,6 +31,7 @@ import type { AgentSession } from "../types.ts";
 import { isProcessRunning } from "../watchdog/health.ts";
 import type { SessionState } from "../worktree/tmux.ts";
 import {
+	buildProjectTmuxCliArgs,
 	capturePaneContent,
 	checkSessionState,
 	createSession,
@@ -597,7 +598,7 @@ export async function startCoordinatorSession(
 		}
 
 		if (shouldAttach) {
-			Bun.spawnSync(["tmux", "attach-session", "-t", tmuxSession], {
+			Bun.spawnSync(buildProjectTmuxCliArgs(["attach-session", "-t", tmuxSession], projectRoot), {
 				stdio: ["inherit", "inherit", "inherit"],
 			});
 		}

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -20,10 +20,14 @@ import { doctorCommand } from "./doctor.ts";
 describe("doctorCommand", () => {
 	let chunks: string[];
 	let originalWrite: typeof process.stdout.write;
+	let originalExitCode: number | undefined;
 	let tempDir: string;
 	let originalCwd: string;
 
 	beforeEach(async () => {
+		originalExitCode = process.exitCode as number | undefined;
+		process.exitCode = 0;
+
 		// Spy on stdout
 		chunks = [];
 		originalWrite = process.stdout.write;
@@ -46,6 +50,7 @@ describe("doctorCommand", () => {
 	});
 
 	afterEach(async () => {
+		process.exitCode = originalExitCode ?? 0;
 		process.stdout.write = originalWrite;
 		process.chdir(originalCwd);
 		await cleanupTempDir(tempDir);
@@ -257,6 +262,12 @@ describe("doctorCommand", () => {
 		});
 
 		test("returns undefined on success (no failures)", async () => {
+			const exitCode = await doctorCommand([], { checkRunners: [] });
+			expect(exitCode).toBeUndefined();
+		});
+
+		test("ignores ambient nonzero process.exitCode on success", async () => {
+			process.exitCode = 1;
 			const exitCode = await doctorCommand([], { checkRunners: [] });
 			expect(exitCode).toBeUndefined();
 		});

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -252,12 +252,14 @@ export async function doctorCommand(
 	cmd.exitOverride();
 
 	const prevExitCode = process.exitCode as number | undefined;
-	process.exitCode = undefined;
+	// Bun does not reliably clear a nonzero exitCode when reassigned to undefined,
+	// so use 0 as the neutral sentinel while this command runs.
+	process.exitCode = 0;
 
 	try {
 		await cmd.parseAsync(args, { from: "user" });
 	} catch (err: unknown) {
-		process.exitCode = prevExitCode;
+		process.exitCode = prevExitCode ?? 0;
 		if (err && typeof err === "object" && "code" in err) {
 			const code = (err as { code: string }).code;
 			if (code === "commander.helpDisplayed" || code === "commander.version") {
@@ -268,6 +270,6 @@ export async function doctorCommand(
 	}
 
 	const exitCode = process.exitCode === 1 ? 1 : undefined;
-	process.exitCode = prevExitCode;
+	process.exitCode = prevExitCode ?? 0;
 	return exitCode;
 }

--- a/src/commands/inspect.test.ts
+++ b/src/commands/inspect.test.ts
@@ -8,7 +8,7 @@
  * SessionStore, MetricsStore). No mocks needed -- all dependencies are cheap and local.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { mkdir, mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -236,6 +236,65 @@ describe("inspectCommand", () => {
 			expect(data.session.taskId).toBe("overstory-001");
 			expect(data.timeSinceLastActivity).toBeGreaterThan(4000);
 			expect(data.timeSinceLastActivity).toBeLessThan(10000);
+		});
+
+		test("captures tmux output through the project's isolated socket", async () => {
+			const overstoryDir = join(tempDir, ".overstory");
+			const sessionsDbPath = join(overstoryDir, "sessions.db");
+			const store = createSessionStore(sessionsDbPath);
+			store.upsert({
+				id: "sess-1",
+				agentName: "builder-1",
+				capability: "builder",
+				worktreePath: "/tmp/wt",
+				branchName: "overstory/builder-1/test",
+				taskId: "overstory-001",
+				tmuxSession: "overstory-test-builder-1",
+				state: "working",
+				pid: 12345,
+				parentAgent: null,
+				depth: 0,
+				runId: null,
+				startedAt: new Date().toISOString(),
+				lastActivity: new Date().toISOString(),
+				escalationLevel: 0,
+				stalledSince: null,
+				transcriptPath: null,
+			});
+			store.close();
+
+			const otherCwd = await mkdtemp(join(tmpdir(), "inspect-other-cwd-"));
+			const spawnSpy = spyOn(Bun, "spawn");
+			spawnSpy.mockImplementation((...args: unknown[]) => {
+				const cmd = args[0] as string[];
+				expect(cmd).toEqual([
+					"tmux",
+					"-S",
+					join(tempDir, ".overstory", "tmux.sock"),
+					"capture-pane",
+					"-t",
+					"overstory-test-builder-1",
+					"-p",
+					"-S",
+					"-12",
+				]);
+				return {
+					stdout: new Response("live pane output\n").body as ReadableStream<Uint8Array>,
+					stderr: new Response("").body as ReadableStream<Uint8Array>,
+					exited: Promise.resolve(0),
+					pid: 12345,
+				} as unknown as ReturnType<typeof Bun.spawn>;
+			});
+
+			try {
+				process.chdir(otherCwd);
+				const data = await gatherInspectData(tempDir, "builder-1", { tmuxLines: 12 });
+				expect(data.tmuxOutput).toBe("live pane output");
+			} finally {
+				spawnSpy.mockRestore();
+				process.chdir(tempDir);
+				await cleanupTempDir(otherCwd);
+			}
 		});
 
 		test("extracts current file from recent Edit tool_start event", async () => {

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -18,6 +18,7 @@ import { renderHeader, separator, stateIconColored } from "../logging/theme.ts";
 import { createMetricsStore } from "../metrics/store.ts";
 import { openSessionStore } from "../sessions/compat.ts";
 import type { AgentSession, StoredEvent, ToolStats } from "../types.ts";
+import { buildProjectTmuxCliArgs } from "../worktree/tmux.ts";
 
 /**
  * Extract current file from most recent Edit/Write/Read tool_start event.
@@ -70,12 +71,22 @@ function summarizeArgs(toolArgs: string | null): string {
 /**
  * Capture tmux pane output.
  */
-async function captureTmux(sessionName: string, lines: number): Promise<string | null> {
+async function captureTmux(
+	sessionName: string,
+	lines: number,
+	projectRoot: string,
+): Promise<string | null> {
 	try {
-		const proc = Bun.spawn(["tmux", "capture-pane", "-t", sessionName, "-p", "-S", `-${lines}`], {
-			stdout: "pipe",
-			stderr: "pipe",
-		});
+		const proc = Bun.spawn(
+			buildProjectTmuxCliArgs(
+				["capture-pane", "-t", sessionName, "-p", "-S", `-${lines}`],
+				projectRoot,
+			),
+			{
+				stdout: "pipe",
+				stderr: "pipe",
+			},
+		);
 		const exitCode = await proc.exited;
 		if (exitCode !== 0) {
 			return null;
@@ -368,7 +379,7 @@ export async function gatherInspectData(
 		let tmuxOutput: string | null = null;
 		if (!opts.noTmux && session.tmuxSession) {
 			const lines = opts.tmuxLines ?? 30;
-			tmuxOutput = await captureTmux(session.tmuxSession, lines);
+			tmuxOutput = await captureTmux(session.tmuxSession, lines, root);
 		}
 
 		// Headless stdout.log fallback: parse NDJSON event stream for rich activity data.

--- a/src/commands/monitor.ts
+++ b/src/commands/monitor.ts
@@ -25,7 +25,13 @@ import { printHint, printSuccess } from "../logging/color.ts";
 import { getRuntime } from "../runtimes/registry.ts";
 import { openSessionStore } from "../sessions/compat.ts";
 import type { AgentSession } from "../types.ts";
-import { createSession, isSessionAlive, killSession, sendKeys } from "../worktree/tmux.ts";
+import {
+	buildProjectTmuxCliArgs,
+	createSession,
+	isSessionAlive,
+	killSession,
+	sendKeys,
+} from "../worktree/tmux.ts";
 import { isRunningAsRoot } from "./sling.ts";
 
 /** Default monitor agent name. */
@@ -215,7 +221,7 @@ async function startMonitor(opts: { json: boolean; attach: boolean }): Promise<v
 		}
 
 		if (shouldAttach) {
-			Bun.spawnSync(["tmux", "attach-session", "-t", tmuxSession], {
+			Bun.spawnSync(buildProjectTmuxCliArgs(["attach-session", "-t", tmuxSession], projectRoot), {
 				stdio: ["inherit", "inherit", "inherit"],
 			});
 		}

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -65,7 +65,7 @@ describe("sessions command", () => {
 		} else {
 			process.env.TMUX = originalTmux;
 		}
-		process.exitCode = undefined;
+		process.exitCode = 0;
 		await cleanupTempDir(tempDir);
 	});
 

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createSessionStore } from "../sessions/store.ts";
+import { cleanupTempDir } from "../test-helpers.ts";
+import type { AgentSession } from "../types.ts";
+import { createSessionsCommand } from "./sessions.ts";
+
+function makeSession(overrides: Partial<AgentSession> = {}): AgentSession {
+	return {
+		id: "session-1",
+		agentName: "builder-1",
+		capability: "builder",
+		worktreePath: "/tmp/wt",
+		branchName: "overstory/builder-1/task-1",
+		taskId: "task-1",
+		tmuxSession: "overstory-test-builder-1",
+		state: "working",
+		pid: 12345,
+		parentAgent: null,
+		depth: 0,
+		runId: null,
+		startedAt: new Date().toISOString(),
+		lastActivity: new Date().toISOString(),
+		escalationLevel: 0,
+		stalledSince: null,
+		transcriptPath: null,
+		...overrides,
+	};
+}
+
+describe("sessions command", () => {
+	let tempDir: string;
+	let originalCwd: string;
+	let originalTmux: string | undefined;
+	let stdoutChunks: string[];
+	let stdoutSpy: ReturnType<typeof spyOn>;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "overstory-sessions-test-"));
+		originalCwd = process.cwd();
+		originalTmux = process.env.TMUX;
+		stdoutChunks = [];
+		process.chdir(tempDir);
+
+		await Bun.write(
+			join(tempDir, ".overstory", "config.yaml"),
+			["project:", "  name: test-project", `  root: ${tempDir}`, "  canonicalBranch: main"].join(
+				"\n",
+			),
+		);
+
+		stdoutSpy = spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+			stdoutChunks.push(String(chunk));
+			return true;
+		});
+	});
+
+	afterEach(async () => {
+		stdoutSpy.mockRestore();
+		process.chdir(originalCwd);
+		if (originalTmux === undefined) {
+			delete process.env.TMUX;
+		} else {
+			process.env.TMUX = originalTmux;
+		}
+		process.exitCode = undefined;
+		await cleanupTempDir(tempDir);
+	});
+
+	function outputJson(): Record<string, unknown> {
+		return JSON.parse(stdoutChunks.join("").trim()) as Record<string, unknown>;
+	}
+
+	async function runSessions(args: string[]): Promise<void> {
+		const cmd = createSessionsCommand();
+		cmd.exitOverride();
+		await cmd.parseAsync(args, { from: "user" });
+	}
+
+	test("list --json shows attachable sessions with alive state", async () => {
+		const store = createSessionStore(join(tempDir, ".overstory", "sessions.db"));
+		store.upsert(makeSession());
+		store.close();
+
+		const spawnSpy = spyOn(Bun, "spawn").mockImplementation(() => {
+			return {
+				stdout: new Response("").body as ReadableStream<Uint8Array>,
+				stderr: new Response("").body as ReadableStream<Uint8Array>,
+				exited: Promise.resolve(0),
+				pid: 12345,
+			} as unknown as ReturnType<typeof Bun.spawn>;
+		});
+
+		try {
+			await runSessions(["list", "--json"]);
+		} finally {
+			spawnSpy.mockRestore();
+		}
+
+		const payload = outputJson();
+		expect(payload.success).toBe(true);
+		expect(payload.command).toBe("sessions list");
+		expect(payload.sessions).toEqual([
+			{
+				agentName: "builder-1",
+				tmuxSession: "overstory-test-builder-1",
+				capability: "builder",
+				state: "working",
+				alive: true,
+			},
+		]);
+	});
+
+	test("attach --json prefers coordinator when no agent is specified", async () => {
+		const store = createSessionStore(join(tempDir, ".overstory", "sessions.db"));
+		store.upsert(
+			makeSession({
+				id: "session-coordinator",
+				agentName: "coordinator",
+				capability: "coordinator",
+				tmuxSession: "overstory-test-coordinator",
+			}),
+		);
+		store.upsert(makeSession());
+		store.close();
+
+		const spawnSpy = spyOn(Bun, "spawn").mockImplementation(() => {
+			return {
+				stdout: new Response("").body as ReadableStream<Uint8Array>,
+				stderr: new Response("").body as ReadableStream<Uint8Array>,
+				exited: Promise.resolve(0),
+				pid: 12345,
+			} as unknown as ReturnType<typeof Bun.spawn>;
+		});
+
+		try {
+			await runSessions(["attach", "--json"]);
+		} finally {
+			spawnSpy.mockRestore();
+		}
+
+		const payload = outputJson();
+		expect(payload.success).toBe(true);
+		expect(payload.command).toBe("sessions attach");
+		expect(payload.ok).toBe(true);
+		expect(payload.agentName).toBe("coordinator");
+		expect(payload.tmuxSession).toBe("overstory-test-coordinator");
+	});
+
+	test("attach --json returns ambiguous when multiple worker sessions exist", async () => {
+		const store = createSessionStore(join(tempDir, ".overstory", "sessions.db"));
+		store.upsert(makeSession());
+		store.upsert(
+			makeSession({
+				id: "session-2",
+				agentName: "builder-2",
+				tmuxSession: "overstory-test-builder-2",
+			}),
+		);
+		store.close();
+
+		await runSessions(["attach", "--json"]);
+
+		const payload = outputJson();
+		expect(payload.success).toBe(true);
+		expect(payload.command).toBe("sessions attach");
+		expect(payload.ok).toBe(false);
+		expect(payload.reason).toBe("ambiguous");
+	});
+
+	test("current --json returns null and sets exitCode when outside tmux", async () => {
+		delete process.env.TMUX;
+
+		await runSessions(["current", "--json"]);
+
+		const payload = outputJson();
+		expect(payload.success).toBe(true);
+		expect(payload.command).toBe("sessions current");
+		expect(payload.tmuxSession).toBeNull();
+		expect(process.exitCode).toBe(1);
+	});
+});

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -1,0 +1,268 @@
+/**
+ * CLI command: ov sessions <subcommand>
+ *
+ * Manage overstory-managed tmux sessions through the project's isolated
+ * tmux socket. This provides a user-facing roof over list/attach/kill
+ * without requiring direct `tmux -S ...` usage.
+ */
+
+import { join } from "node:path";
+import { Command } from "commander";
+import { loadConfig } from "../config.ts";
+import { jsonOutput } from "../json.ts";
+import { accent, printError, printHint } from "../logging/color.ts";
+import { openSessionStore } from "../sessions/compat.ts";
+import type { AgentSession } from "../types.ts";
+import {
+	buildProjectTmuxCliArgs,
+	getCurrentSessionName,
+	isSessionAlive,
+	killSession,
+} from "../worktree/tmux.ts";
+
+function attachableSessions(sessions: readonly AgentSession[]): AgentSession[] {
+	return sessions.filter((session) => session.tmuxSession.trim().length > 0);
+}
+
+function listSessionHints(sessions: readonly AgentSession[]): void {
+	if (sessions.length === 0) {
+		printHint("No attachable tmux sessions found.");
+		return;
+	}
+
+	printHint("Attachable sessions:");
+	for (const session of sessions) {
+		printHint(
+			`  ${session.agentName} -> ${session.tmuxSession} (${session.capability}, ${session.state})`,
+		);
+	}
+}
+
+function resolveTargetSession(
+	sessions: readonly AgentSession[],
+	requested?: string,
+): { session: AgentSession | null; reason?: "ambiguous" | "missing" } {
+	if (requested) {
+		const match =
+			sessions.find((session) => session.agentName === requested) ??
+			sessions.find((session) => session.tmuxSession === requested) ??
+			null;
+		return { session: match, reason: match ? undefined : "missing" };
+	}
+
+	const coordinator = sessions.find((session) => session.agentName === "coordinator");
+	if (coordinator) {
+		return { session: coordinator };
+	}
+
+	const monitor = sessions.find((session) => session.agentName === "monitor");
+	if (monitor) {
+		return { session: monitor };
+	}
+
+	if (sessions.length === 1) {
+		return { session: sessions[0] ?? null };
+	}
+
+	return { session: null, reason: sessions.length === 0 ? "missing" : "ambiguous" };
+}
+
+async function loadAttachableSessions(
+	projectRoot: string,
+	includeAll = false,
+): Promise<AgentSession[]> {
+	const overstoryDir = join(projectRoot, ".overstory");
+	const { store } = openSessionStore(overstoryDir);
+	try {
+		return attachableSessions(includeAll ? store.getAll() : store.getActive());
+	} finally {
+		store.close();
+	}
+}
+
+async function attachToSession(
+	projectRoot: string,
+	sessions: readonly AgentSession[],
+	agent: string | undefined,
+	json: boolean,
+): Promise<void> {
+	const resolved = resolveTargetSession(sessions, agent);
+
+	if (!resolved.session) {
+		if (json) {
+			jsonOutput("sessions attach", {
+				ok: false,
+				reason: resolved.reason ?? "missing",
+				requested: agent ?? null,
+				sessions: sessions.map((session) => ({
+					agentName: session.agentName,
+					tmuxSession: session.tmuxSession,
+					capability: session.capability,
+					state: session.state,
+				})),
+			});
+			process.exitCode = 1;
+			return;
+		}
+
+		if (resolved.reason === "ambiguous") {
+			printError("Multiple attachable sessions found", "pass an agent name");
+		} else {
+			printError("No matching attachable session found", agent);
+		}
+		listSessionHints(sessions);
+		process.exitCode = 1;
+		return;
+	}
+
+	const alive = await isSessionAlive(resolved.session.tmuxSession);
+	if (!alive) {
+		if (json) {
+			jsonOutput("sessions attach", {
+				ok: false,
+				reason: "dead",
+				agentName: resolved.session.agentName,
+				tmuxSession: resolved.session.tmuxSession,
+			});
+			process.exitCode = 1;
+			return;
+		}
+
+		printError(
+			"Tmux session is not alive",
+			`${resolved.session.agentName} -> ${resolved.session.tmuxSession}`,
+		);
+		process.exitCode = 1;
+		return;
+	}
+
+	if (json) {
+		jsonOutput("sessions attach", {
+			ok: true,
+			agentName: resolved.session.agentName,
+			tmuxSession: resolved.session.tmuxSession,
+		});
+		return;
+	}
+
+	printHint(`Attaching to ${accent(resolved.session.agentName)} (${resolved.session.tmuxSession})`);
+	Bun.spawnSync(
+		buildProjectTmuxCliArgs(["attach-session", "-t", resolved.session.tmuxSession], projectRoot),
+		{
+			stdio: ["inherit", "inherit", "inherit"],
+		},
+	);
+}
+
+export function createSessionsCommand(): Command {
+	const cmd = new Command("sessions").description("Manage isolated overstory tmux sessions");
+
+	cmd
+		.command("list")
+		.alias("ls")
+		.description("List overstory-managed tmux sessions")
+		.option("--all", "Include completed and zombie sessions")
+		.option("--json", "Output as JSON")
+		.action(async (opts: { all?: boolean; json?: boolean }) => {
+			const config = await loadConfig(process.cwd());
+			const projectRoot = config.project.root;
+			const sessions = await loadAttachableSessions(projectRoot, opts.all ?? false);
+			const rows = await Promise.all(
+				sessions.map(async (session) => ({
+					agentName: session.agentName,
+					tmuxSession: session.tmuxSession,
+					capability: session.capability,
+					state: session.state,
+					alive: await isSessionAlive(session.tmuxSession),
+				})),
+			);
+
+			if (opts.json) {
+				jsonOutput("sessions list", { sessions: rows });
+				return;
+			}
+
+			if (rows.length === 0) {
+				printHint("No attachable tmux sessions found.");
+				return;
+			}
+
+			for (const row of rows) {
+				printHint(
+					`${row.agentName} -> ${row.tmuxSession} (${row.capability}, ${row.state}, ${
+						row.alive ? "alive" : "dead"
+					})`,
+				);
+			}
+		});
+
+	cmd
+		.command("attach")
+		.description("Attach to an active overstory tmux session")
+		.argument("[agent]", "Agent name or tmux session name")
+		.option("--json", "Output as JSON")
+		.action(async (agent: string | undefined, opts: { json?: boolean }) => {
+			const config = await loadConfig(process.cwd());
+			const projectRoot = config.project.root;
+			const sessions = await loadAttachableSessions(projectRoot, false);
+			await attachToSession(projectRoot, sessions, agent, opts.json ?? false);
+		});
+
+	cmd
+		.command("kill")
+		.description("Kill an overstory tmux session by agent or session name")
+		.argument("<agent>", "Agent name or tmux session name")
+		.option("--json", "Output as JSON")
+		.action(async (agent: string, opts: { json?: boolean }) => {
+			const config = await loadConfig(process.cwd());
+			const projectRoot = config.project.root;
+			const sessions = await loadAttachableSessions(projectRoot, true);
+			const resolved = resolveTargetSession(sessions, agent);
+
+			if (!resolved.session) {
+				if (opts.json) {
+					jsonOutput("sessions kill", {
+						ok: false,
+						reason: resolved.reason ?? "missing",
+						requested: agent,
+					});
+				} else {
+					printError("No matching attachable session found", agent);
+				}
+				process.exitCode = 1;
+				return;
+			}
+
+			await killSession(resolved.session.tmuxSession);
+			if (opts.json) {
+				jsonOutput("sessions kill", {
+					ok: true,
+					agentName: resolved.session.agentName,
+					tmuxSession: resolved.session.tmuxSession,
+				});
+			} else {
+				printHint(`Killed ${resolved.session.agentName} (${resolved.session.tmuxSession})`);
+			}
+		});
+
+	cmd
+		.command("current")
+		.description("Print the current tmux session name when inside overstory tmux")
+		.option("--json", "Output as JSON")
+		.action(async (opts: { json?: boolean }) => {
+			const sessionName = await getCurrentSessionName();
+			if (opts.json) {
+				jsonOutput("sessions current", { tmuxSession: sessionName });
+				if (!sessionName) process.exitCode = 1;
+				return;
+			}
+			if (!sessionName) {
+				printError("Not running inside a tmux session");
+				process.exitCode = 1;
+				return;
+			}
+			process.stdout.write(`${sessionName}\n`);
+		});
+
+	return cmd;
+}

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -10,7 +10,7 @@ import { join } from "node:path";
 import { Command } from "commander";
 import { loadConfig } from "../config.ts";
 import { jsonOutput } from "../json.ts";
-import { accent, printError, printHint } from "../logging/color.ts";
+import { accent, muted, printError, printHint, printSuccess } from "../logging/color.ts";
 import { openSessionStore } from "../sessions/compat.ts";
 import type { AgentSession } from "../types.ts";
 import {
@@ -32,8 +32,8 @@ function listSessionHints(sessions: readonly AgentSession[]): void {
 
 	printHint("Attachable sessions:");
 	for (const session of sessions) {
-		printHint(
-			`  ${session.agentName} -> ${session.tmuxSession} (${session.capability}, ${session.state})`,
+		console.log(
+			`  ${accent(session.agentName)} -> ${session.tmuxSession} ${muted(`(${session.capability}, ${session.state})`)}`,
 		);
 	}
 }
@@ -129,7 +129,7 @@ async function attachToSession(
 		}
 
 		printError(
-			"Tmux session is not alive",
+			"tmux session is not alive",
 			`${resolved.session.agentName} -> ${resolved.session.tmuxSession}`,
 		);
 		process.exitCode = 1;
@@ -145,7 +145,7 @@ async function attachToSession(
 		return;
 	}
 
-	printHint(`Attaching to ${accent(resolved.session.agentName)} (${resolved.session.tmuxSession})`);
+	printSuccess(`Attaching to ${resolved.session.agentName}`, resolved.session.tmuxSession);
 	Bun.spawnSync(
 		buildProjectTmuxCliArgs(["attach-session", "-t", resolved.session.tmuxSession], projectRoot),
 		{
@@ -188,10 +188,8 @@ export function createSessionsCommand(): Command {
 			}
 
 			for (const row of rows) {
-				printHint(
-					`${row.agentName} -> ${row.tmuxSession} (${row.capability}, ${row.state}, ${
-						row.alive ? "alive" : "dead"
-					})`,
+				console.log(
+					`${accent(row.agentName)} -> ${row.tmuxSession} ${muted(`(${row.capability}, ${row.state}, ${row.alive ? "alive" : "dead"})`)}`,
 				);
 			}
 		});
@@ -241,7 +239,7 @@ export function createSessionsCommand(): Command {
 					tmuxSession: resolved.session.tmuxSession,
 				});
 			} else {
-				printHint(`Killed ${resolved.session.agentName} (${resolved.session.tmuxSession})`);
+				printSuccess(`Killed ${resolved.session.agentName}`, resolved.session.tmuxSession);
 			}
 		});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import { nudgeCommand } from "./commands/nudge.ts";
 import { primeCommand } from "./commands/prime.ts";
 import { createReplayCommand } from "./commands/replay.ts";
 import { createRunCommand } from "./commands/run.ts";
+import { createSessionsCommand } from "./commands/sessions.ts";
 import { slingCommand } from "./commands/sling.ts";
 import { specWriteCommand } from "./commands/spec.ts";
 import { createStatusCommand } from "./commands/status.ts";
@@ -76,6 +77,7 @@ const COMMANDS = [
 	"prime",
 	"stop",
 	"status",
+	"sessions",
 	"dashboard",
 	"discover",
 	"inspect",
@@ -239,6 +241,7 @@ program.addCommand(createCoordinatorCommand());
 program.addCommand(createSupervisorCommand());
 program.addCommand(createHooksCommand());
 program.addCommand(createMonitorCommand());
+program.addCommand(createSessionsCommand());
 program.addCommand(createWorktreeCommand());
 program.addCommand(createLogCommand());
 program.addCommand(createWatchCommand());

--- a/src/worktree/tmux.test.ts
+++ b/src/worktree/tmux.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { AgentError } from "../errors.ts";
 import type { ReadyState } from "../runtimes/types.ts";
 import {
@@ -45,6 +48,20 @@ function mockSpawnResult(
 		pid: 12345,
 	};
 }
+
+let originalCwd: string;
+let tempCwd: string;
+
+beforeEach(async () => {
+	originalCwd = process.cwd();
+	tempCwd = await mkdtemp(join(tmpdir(), "overstory-tmux-cwd-"));
+	process.chdir(tempCwd);
+});
+
+afterEach(async () => {
+	process.chdir(originalCwd);
+	await rm(tempCwd, { recursive: true, force: true });
+});
 
 describe("createSession", () => {
 	let spawnSpy: ReturnType<typeof spyOn>;
@@ -269,6 +286,42 @@ describe("createSession", () => {
 		expect(spawnSpy).toHaveBeenCalledTimes(4);
 	});
 
+	test("uses project-local tmux socket and config when .overstory/tmux.conf exists", async () => {
+		await mkdir(join(tempCwd, ".overstory"), { recursive: true });
+		await Bun.write(join(tempCwd, ".overstory", "tmux.conf"), "set -g mouse on\n");
+
+		let callCount = 0;
+		spawnSpy.mockImplementation(() => {
+			callCount++;
+			if (callCount === 1) {
+				return mockSpawnResult("/usr/local/bin/overstory\n", "", 0);
+			}
+			if (callCount === 2) {
+				return mockSpawnResult("", "", 0);
+			}
+			return mockSpawnResult("4242\n", "", 0);
+		});
+
+		await createSession("isolated-agent", tempCwd, "echo hello");
+
+		const tmuxCallArgs = spawnSpy.mock.calls[1] as unknown[];
+		const cmd = tmuxCallArgs[0] as string[];
+		expect(cmd).toEqual([
+			"tmux",
+			"-S",
+			join(tempCwd, ".overstory", "tmux.sock"),
+			"-f",
+			join(tempCwd, ".overstory", "tmux.conf"),
+			"new-session",
+			"-d",
+			"-s",
+			"isolated-agent",
+			"-c",
+			tempCwd,
+			expect.any(String),
+		]);
+	});
+
 	test("throws after exhausting all list-panes retries", async () => {
 		let callCount = 0;
 		spawnSpy.mockImplementation(() => {
@@ -361,6 +414,24 @@ describe("listSessions", () => {
 		const callArgs = spawnSpy.mock.calls[0] as unknown[];
 		const cmd = callArgs[0] as string[];
 		expect(cmd).toEqual(["tmux", "list-sessions", "-F", "#{session_name}:#{pid}"]);
+	});
+
+	test("uses project-local tmux socket when .overstory exists", async () => {
+		await mkdir(join(tempCwd, ".overstory"), { recursive: true });
+		spawnSpy.mockImplementation(() => mockSpawnResult("", "", 0));
+
+		await listSessions();
+
+		const callArgs = spawnSpy.mock.calls[0] as unknown[];
+		const cmd = callArgs[0] as string[];
+		expect(cmd).toEqual([
+			"tmux",
+			"-S",
+			join(tempCwd, ".overstory", "tmux.sock"),
+			"list-sessions",
+			"-F",
+			"#{session_name}:#{pid}",
+		]);
 	});
 });
 
@@ -759,6 +830,21 @@ describe("killSession", () => {
 		killSpy.mockImplementation(() => true);
 
 		// Should not throw — session disappearing is expected
+		await killSession("overstory-auth");
+	});
+
+	test("succeeds silently when the isolated tmux server is already gone", async () => {
+		spawnSpy.mockImplementation((...args: unknown[]) => {
+			const cmd = args[0] as string[];
+			if (cmd[0] === "tmux" && cmd[1] === "display-message") {
+				return mockSpawnResult("", "can't find session", 1);
+			}
+			if (cmd[0] === "tmux" && cmd[1] === "kill-session") {
+				return mockSpawnResult("", "no server running on /tmp/isolated.sock", 1);
+			}
+			return mockSpawnResult("", "", 0);
+		});
+
 		await killSession("overstory-auth");
 	});
 

--- a/src/worktree/tmux.test.ts
+++ b/src/worktree/tmux.test.ts
@@ -9,6 +9,7 @@ import {
 	checkSessionState,
 	createSession,
 	ensureTmuxAvailable,
+	getCurrentSessionName,
 	getDescendantPids,
 	getPanePid,
 	isProcessAlive,
@@ -901,6 +902,21 @@ describe("killSession", () => {
 		await expect(killSession("broken-session")).rejects.toThrow(AgentError);
 	});
 
+	test("does not swallow unrelated errors that mention session text", async () => {
+		spawnSpy.mockImplementation((...args: unknown[]) => {
+			const cmd = args[0] as string[];
+			if (cmd[0] === "tmux" && cmd[1] === "display-message") {
+				return mockSpawnResult("", "can't find session", 1);
+			}
+			if (cmd[0] === "tmux" && cmd[1] === "kill-session") {
+				return mockSpawnResult("", "failed to find session lockfile", 1);
+			}
+			return mockSpawnResult("", "", 0);
+		});
+
+		await expect(killSession("broken-session")).rejects.toThrow(AgentError);
+	});
+
 	test("AgentError contains session name on failure", async () => {
 		spawnSpy.mockImplementation((...args: unknown[]) => {
 			const cmd = args[0] as string[];
@@ -922,6 +938,47 @@ describe("killSession", () => {
 			expect(agentErr.message).toContain("ghost-agent");
 			expect(agentErr.agentName).toBe("ghost-agent");
 		}
+	});
+});
+
+describe("getCurrentSessionName", () => {
+	let spawnSpy: ReturnType<typeof spyOn>;
+	let originalTmux: string | undefined;
+
+	beforeEach(() => {
+		spawnSpy = spyOn(Bun, "spawn");
+		originalTmux = process.env.TMUX;
+	});
+
+	afterEach(() => {
+		spawnSpy.mockRestore();
+		if (originalTmux === undefined) {
+			delete process.env.TMUX;
+		} else {
+			process.env.TMUX = originalTmux;
+		}
+	});
+
+	test("returns null when not running inside tmux", async () => {
+		delete process.env.TMUX;
+
+		const sessionName = await getCurrentSessionName();
+
+		expect(sessionName).toBeNull();
+		expect(spawnSpy).not.toHaveBeenCalled();
+	});
+
+	test("queries the current tmux server without the project socket override", async () => {
+		process.env.TMUX = "/tmp/tmux-1000/default,123,0";
+		spawnSpy.mockImplementation(() => mockSpawnResult("personal-session\n", "", 0));
+
+		const sessionName = await getCurrentSessionName();
+
+		expect(sessionName).toBe("personal-session");
+		expect(spawnSpy).toHaveBeenCalledTimes(1);
+		const callArgs = spawnSpy.mock.calls[0] as unknown[];
+		const cmd = callArgs[0] as string[];
+		expect(cmd).toEqual(["tmux", "display-message", "-p", "#{session_name}"]);
 	});
 });
 

--- a/src/worktree/tmux.test.ts
+++ b/src/worktree/tmux.test.ts
@@ -322,6 +322,44 @@ describe("createSession", () => {
 		]);
 	});
 
+	test("uses canonical project tmux socket when cwd is an overstory worktree with its own copied .overstory", async () => {
+		const projectOverstoryDir = join(tempCwd, ".overstory");
+		const worktreePath = join(projectOverstoryDir, "worktrees", "builder-123");
+		await mkdir(join(worktreePath, ".overstory"), { recursive: true });
+		await Bun.write(join(projectOverstoryDir, "tmux.conf"), "set -g mouse on\n");
+
+		let callCount = 0;
+		spawnSpy.mockImplementation(() => {
+			callCount++;
+			if (callCount === 1) {
+				return mockSpawnResult("/usr/local/bin/overstory\n", "", 0);
+			}
+			if (callCount === 2) {
+				return mockSpawnResult("", "", 0);
+			}
+			return mockSpawnResult("4242\n", "", 0);
+		});
+
+		await createSession("isolated-agent", worktreePath, "echo hello");
+
+		const tmuxCallArgs = spawnSpy.mock.calls[1] as unknown[];
+		const cmd = tmuxCallArgs[0] as string[];
+		expect(cmd).toEqual([
+			"tmux",
+			"-S",
+			join(projectOverstoryDir, "tmux.sock"),
+			"-f",
+			join(projectOverstoryDir, "tmux.conf"),
+			"new-session",
+			"-d",
+			"-s",
+			"isolated-agent",
+			"-c",
+			worktreePath,
+			expect.any(String),
+		]);
+	});
+
 	test("throws after exhausting all list-panes retries", async () => {
 		let callCount = 0;
 		spawnSpy.mockImplementation(() => {

--- a/src/worktree/tmux.ts
+++ b/src/worktree/tmux.ts
@@ -456,7 +456,8 @@ export async function killSession(name: string): Promise<void> {
 		// If the session is already gone (e.g., died during process cleanup), that's fine
 		if (
 			stderr.includes("session not found") ||
-			stderr.includes("find session") ||
+			stderr.includes("can't find session") ||
+			stderr.includes("cant find session") ||
 			stderr.includes("no server running")
 		) {
 			return;
@@ -478,7 +479,8 @@ export async function getCurrentSessionName(): Promise<string | null> {
 	if (!process.env.TMUX) {
 		return null;
 	}
-	const { exitCode, stdout } = await runProjectTmuxCommand([
+	const { exitCode, stdout } = await runCommand([
+		"tmux",
 		"display-message",
 		"-p",
 		"#{session_name}",

--- a/src/worktree/tmux.ts
+++ b/src/worktree/tmux.ts
@@ -7,9 +7,65 @@
  * and enables project-scoped cleanup (overstory-pcef).
  */
 
-import { dirname, resolve } from "node:path";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { getProjectRootOverride } from "../config.ts";
 import { AgentError } from "../errors.ts";
 import type { ReadyState } from "../runtimes/types.ts";
+
+const OVERSTORY_DIRNAME = ".overstory";
+const TMUX_SOCKET_FILENAME = "tmux.sock";
+const TMUX_CONFIG_FILENAME = "tmux.conf";
+
+function findOverstoryDir(startDir?: string): string | null {
+	let current = resolve(startDir ?? getProjectRootOverride() ?? process.cwd());
+
+	while (true) {
+		const candidate = join(current, OVERSTORY_DIRNAME);
+		if (existsSync(candidate)) {
+			return candidate;
+		}
+		const parent = dirname(current);
+		if (parent === current) {
+			return null;
+		}
+		current = parent;
+	}
+}
+
+function buildProjectTmuxCommand(args: string[], cwd?: string, includeConfig = false): string[] {
+	const cmd = ["tmux"];
+	const overstoryDir = findOverstoryDir(cwd);
+
+	if (overstoryDir) {
+		cmd.push("-S", join(overstoryDir, TMUX_SOCKET_FILENAME));
+		if (includeConfig) {
+			const configPath = join(overstoryDir, TMUX_CONFIG_FILENAME);
+			if (existsSync(configPath)) {
+				cmd.push("-f", configPath);
+			}
+		}
+	}
+
+	cmd.push(...args);
+	return cmd;
+}
+
+async function runProjectTmuxCommand(
+	args: string[],
+	cwd?: string,
+	includeConfig = false,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+	return runCommand(buildProjectTmuxCommand(args, cwd, includeConfig), cwd);
+}
+
+export function buildProjectTmuxCliArgs(
+	args: string[],
+	cwd?: string,
+	includeConfig = false,
+): string[] {
+	return buildProjectTmuxCommand(args, cwd, includeConfig);
+}
 
 /**
  * Detect the directory containing the overstory binary.
@@ -122,9 +178,10 @@ export async function createSession(
 	const wrappedCommand =
 		exports.length > 0 ? `/bin/bash -c '${startupScript.replace(/'/g, "'\\''")}'` : command;
 
-	const { exitCode, stderr } = await runCommand(
-		["tmux", "new-session", "-d", "-s", name, "-c", cwd, wrappedCommand],
+	const { exitCode, stderr } = await runProjectTmuxCommand(
+		["new-session", "-d", "-s", name, "-c", cwd, wrappedCommand],
 		cwd,
+		true,
 	);
 
 	if (exitCode !== 0) {
@@ -138,7 +195,7 @@ export async function createSession(
 	// the session exists but the pane hasn't been registered yet (#73).
 	let pidResult: { stdout: string; stderr: string; exitCode: number } | undefined;
 	for (let attempt = 0; attempt < maxRetries; attempt++) {
-		pidResult = await runCommand(["tmux", "list-panes", "-t", name, "-F", "#{pane_pid}"]);
+		pidResult = await runProjectTmuxCommand(["list-panes", "-t", name, "-F", "#{pane_pid}"], cwd);
 		if (pidResult.exitCode === 0) break;
 		await Bun.sleep(250 * (attempt + 1));
 	}
@@ -170,8 +227,7 @@ export async function createSession(
  * @throws AgentError if tmux is not installed
  */
 export async function listSessions(): Promise<Array<{ name: string; pid: number }>> {
-	const { exitCode, stdout, stderr } = await runCommand([
-		"tmux",
+	const { exitCode, stdout, stderr } = await runProjectTmuxCommand([
 		"list-sessions",
 		"-F",
 		"#{session_name}:#{pid}",
@@ -219,8 +275,7 @@ const KILL_GRACE_PERIOD_MS = 2000;
  *          the session doesn't exist or the PID can't be determined
  */
 export async function getPanePid(name: string): Promise<number | null> {
-	const { exitCode, stdout } = await runCommand([
-		"tmux",
+	const { exitCode, stdout } = await runProjectTmuxCommand([
 		"display-message",
 		"-p",
 		"-t",
@@ -383,11 +438,15 @@ export async function killSession(name: string): Promise<void> {
 	}
 
 	// Step 3: Kill the tmux session itself
-	const { exitCode, stderr } = await runCommand(["tmux", "kill-session", "-t", name]);
+	const { exitCode, stderr } = await runProjectTmuxCommand(["kill-session", "-t", name]);
 
 	if (exitCode !== 0) {
 		// If the session is already gone (e.g., died during process cleanup), that's fine
-		if (stderr.includes("session not found") || stderr.includes("can't find session")) {
+		if (
+			stderr.includes("session not found") ||
+			stderr.includes("find session") ||
+			stderr.includes("no server running")
+		) {
 			return;
 		}
 		throw new AgentError(`Failed to kill tmux session "${name}": ${stderr.trim()}`, {
@@ -407,8 +466,7 @@ export async function getCurrentSessionName(): Promise<string | null> {
 	if (!process.env.TMUX) {
 		return null;
 	}
-	const { exitCode, stdout } = await runCommand([
-		"tmux",
+	const { exitCode, stdout } = await runProjectTmuxCommand([
 		"display-message",
 		"-p",
 		"#{session_name}",
@@ -427,7 +485,7 @@ export async function getCurrentSessionName(): Promise<string | null> {
  * @returns true if the session exists, false otherwise
  */
 export async function isSessionAlive(name: string): Promise<boolean> {
-	const { exitCode } = await runCommand(["tmux", "has-session", "-t", name]);
+	const { exitCode } = await runProjectTmuxCommand(["has-session", "-t", name]);
 	return exitCode === 0;
 }
 
@@ -456,7 +514,7 @@ export type SessionState = "alive" | "dead" | "no_server";
  * @returns The session state
  */
 export async function checkSessionState(name: string): Promise<SessionState> {
-	const { exitCode, stderr } = await runCommand(["tmux", "has-session", "-t", name]);
+	const { exitCode, stderr } = await runProjectTmuxCommand(["has-session", "-t", name]);
 	if (exitCode === 0) return "alive";
 	if (stderr.includes("no server running") || stderr.includes("no sessions")) {
 		return "no_server";
@@ -472,8 +530,7 @@ export async function checkSessionState(name: string): Promise<SessionState> {
  * @returns The trimmed pane content, or null if capture fails
  */
 export async function capturePaneContent(name: string, lines = 50): Promise<string | null> {
-	const { exitCode, stdout } = await runCommand([
-		"tmux",
+	const { exitCode, stdout } = await runProjectTmuxCommand([
 		"capture-pane",
 		"-t",
 		name,
@@ -584,8 +641,7 @@ export async function sendKeys(name: string, keys: string, maxRetries = 3): Prom
 	const flatKeys = keys.replace(/\n/g, " ");
 
 	for (let attempt = 0; attempt <= maxRetries; attempt++) {
-		const { exitCode, stderr } = await runCommand([
-			"tmux",
+		const { exitCode, stderr } = await runProjectTmuxCommand([
 			"send-keys",
 			"-t",
 			name,
@@ -640,7 +696,7 @@ export async function sendKeys(name: string, keys: string, maxRetries = 3): Prom
 
 async function sendRawKeys(name: string, keys: string): Promise<void> {
 	const flatKeys = keys.replace(/\n/g, " ");
-	const { exitCode, stderr } = await runCommand(["tmux", "send-keys", "-t", name, flatKeys]);
+	const { exitCode, stderr } = await runProjectTmuxCommand(["send-keys", "-t", name, flatKeys]);
 
 	if (exitCode !== 0) {
 		const trimmedStderr = stderr.trim();

--- a/src/worktree/tmux.ts
+++ b/src/worktree/tmux.ts
@@ -8,7 +8,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
 import { getProjectRootOverride } from "../config.ts";
 import { AgentError } from "../errors.ts";
 import type { ReadyState } from "../runtimes/types.ts";
@@ -17,12 +17,24 @@ const OVERSTORY_DIRNAME = ".overstory";
 const TMUX_SOCKET_FILENAME = "tmux.sock";
 const TMUX_CONFIG_FILENAME = "tmux.conf";
 
+function isNestedWorktreeOverstoryDir(candidate: string): boolean {
+	const normalized = resolve(candidate);
+	const worktreesMarker = `${sep}${OVERSTORY_DIRNAME}${sep}worktrees${sep}`;
+	const worktreesIndex = normalized.indexOf(worktreesMarker);
+	if (worktreesIndex === -1) {
+		return false;
+	}
+
+	const lastOverstoryIndex = normalized.lastIndexOf(`${sep}${OVERSTORY_DIRNAME}`);
+	return lastOverstoryIndex > worktreesIndex;
+}
+
 function findOverstoryDir(startDir?: string): string | null {
 	let current = resolve(startDir ?? getProjectRootOverride() ?? process.cwd());
 
 	while (true) {
 		const candidate = join(current, OVERSTORY_DIRNAME);
-		if (existsSync(candidate)) {
+		if (existsSync(candidate) && !isNestedWorktreeOverstoryDir(candidate)) {
 			return candidate;
 		}
 		const parent = dirname(current);


### PR DESCRIPTION
## Summary
- route tmux operations through a project-local `.overstory/tmux.sock`
- include project-local `tmux.conf` during session creation and add `ov sessions`
- update attach/inspect paths and add focused tmux/sessions tests

## Verification
- bun run typecheck
- bun test src/worktree/tmux.test.ts src/commands/inspect.test.ts src/commands/sessions.test.ts
- bunx @biomejs/biome check src/worktree/tmux.ts src/commands/coordinator.ts src/commands/monitor.ts src/commands/inspect.ts src/commands/sessions.ts src/index.ts src/commands/completions.ts src/worktree/tmux.test.ts src/commands/inspect.test.ts src/commands/sessions.test.ts