### PR TITLE
feat: use AGENTS.md for Pi overlays

### DIFF
--- a/docs/runtime-adapters.md
+++ b/docs/runtime-adapters.md
@@ -89,11 +89,11 @@ were deployed.
 |---------|-------------------|
 | Claude Code | `.claude/CLAUDE.md` |
 | Codex | `AGENTS.md` |
-| Pi | `.claude/CLAUDE.md` |
+| Pi | `AGENTS.md` |
 | Copilot | `.github/copilot-instructions.md` |
 | Cursor | `.cursor/rules/overstory.md` |
 
-Pi reads `.claude/CLAUDE.md` natively, so it shares the same path as Claude Code.
+Pi reads `AGENTS.md` (and also honors `CLAUDE.md`), so Overstory should use the agent-native path.
 
 ---
 
@@ -391,11 +391,11 @@ persistent TUI.
 
 ### Pi (`src/runtimes/pi.ts`)
 
-A TUI runtime for Mario Zechner's Pi coding agent. Pi reads `.claude/CLAUDE.md`
-natively, so it shares the instruction path with Claude Code.
+A TUI runtime for Mario Zechner's Pi coding agent. Pi reads `AGENTS.md`
+as a native context file, so Overstory uses that path for worker overlays.
 
 **Key characteristics:**
-- `id = "pi"`, `instructionPath = ".claude/CLAUDE.md"`
+- `id = "pi"`, `instructionPath = "AGENTS.md"`
 - Spawn command: `pi --model <provider>/<model>`, with model alias expansion
 - Model alias expansion: `expandModel("sonnet")` → `"anthropic/claude-sonnet-4-6"`
   using the configured `modelMap`. Fully-qualified models pass through unchanged.

--- a/src/runtimes/pi.test.ts
+++ b/src/runtimes/pi.test.ts
@@ -14,8 +14,8 @@ describe("PiRuntime", () => {
 			expect(runtime.id).toBe("pi");
 		});
 
-		test("instructionPath is .claude/CLAUDE.md", () => {
-			expect(runtime.instructionPath).toBe(".claude/CLAUDE.md");
+		test("instructionPath is AGENTS.md", () => {
+			expect(runtime.instructionPath).toBe("AGENTS.md");
 		});
 	});
 
@@ -356,7 +356,7 @@ describe("PiRuntime", () => {
 			await rm(tempDir, { recursive: true, force: true });
 		});
 
-		test("writes overlay to .claude/CLAUDE.md when overlay is provided", async () => {
+		test("writes overlay to AGENTS.md when overlay is provided", async () => {
 			const worktreePath = join(tempDir, "worktree");
 
 			await runtime.deployConfig(
@@ -365,7 +365,7 @@ describe("PiRuntime", () => {
 				{ agentName: "test-builder", capability: "builder", worktreePath },
 			);
 
-			const overlayPath = join(worktreePath, ".claude", "CLAUDE.md");
+			const overlayPath = join(worktreePath, "AGENTS.md");
 			const content = await Bun.file(overlayPath).text();
 			expect(content).toBe("# Pi Agent Overlay\nThis is the overlay content.");
 		});
@@ -446,7 +446,7 @@ describe("PiRuntime", () => {
 			expect(content).toContain("\t");
 		});
 
-		test("skips CLAUDE.md when overlay is undefined", async () => {
+		test("skips AGENTS.md when overlay is undefined", async () => {
 			const worktreePath = join(tempDir, "worktree");
 
 			await runtime.deployConfig(worktreePath, undefined, {
@@ -455,7 +455,7 @@ describe("PiRuntime", () => {
 				worktreePath,
 			});
 
-			const overlayPath = join(worktreePath, ".claude", "CLAUDE.md");
+			const overlayPath = join(worktreePath, "AGENTS.md");
 			const overlayExists = await Bun.file(overlayPath).exists();
 			expect(overlayExists).toBe(false);
 		});
@@ -485,13 +485,13 @@ describe("PiRuntime", () => {
 				{ agentName: "test-builder", capability: "builder", worktreePath },
 			);
 
-			const claudeMdExists = await Bun.file(join(worktreePath, ".claude", "CLAUDE.md")).exists();
+			const agentsMdExists = await Bun.file(join(worktreePath, "AGENTS.md")).exists();
 			const guardExists = await Bun.file(
 				join(worktreePath, ".pi", "extensions", "overstory-guard.ts"),
 			).exists();
 			const settingsExists = await Bun.file(join(worktreePath, ".pi", "settings.json")).exists();
 
-			expect(claudeMdExists).toBe(true);
+			expect(agentsMdExists).toBe(true);
 			expect(guardExists).toBe(true);
 			expect(settingsExists).toBe(true);
 		});
@@ -754,7 +754,7 @@ describe("PiRuntime integration: registry resolves 'pi'", () => {
 		const rt = getRuntime("pi");
 		expect(rt).toBeInstanceOf(PiRuntime);
 		expect(rt.id).toBe("pi");
-		expect(rt.instructionPath).toBe(".claude/CLAUDE.md");
+		expect(rt.instructionPath).toBe("AGENTS.md");
 	});
 
 	test("getRuntime rejects truly unknown runtimes", async () => {

--- a/src/runtimes/pi.ts
+++ b/src/runtimes/pi.ts
@@ -38,8 +38,8 @@ export class PiRuntime implements AgentRuntime {
 	/** Stability level. Pi adapter is experimental — not fully validated. */
 	readonly stability = "experimental" as const;
 
-	/** Relative path to the instruction file within a worktree. Pi reads .claude/CLAUDE.md natively. */
-	readonly instructionPath = ".claude/CLAUDE.md";
+	/** Relative path to the instruction file within a worktree. Pi reads AGENTS.md at startup. */
+	readonly instructionPath = "AGENTS.md";
 
 	private readonly config: PiRuntimeConfig;
 
@@ -115,12 +115,12 @@ export class PiRuntime implements AgentRuntime {
 	 * Deploy per-agent instructions and guards to a worktree.
 	 *
 	 * Writes up to three files:
-	 * 1. `.claude/CLAUDE.md` — agent's task-specific overlay. Skipped when overlay is undefined.
+	 * 1. `AGENTS.md` — agent's task-specific overlay. Skipped when overlay is undefined.
 	 * 2. `.pi/extensions/overstory-guard.ts` — Pi guard extension (always deployed).
 	 * 3. `.pi/settings.json` — Pi settings enabling the extensions directory (always deployed).
 	 *
 	 * @param worktreePath - Absolute path to the agent's git worktree
-	 * @param overlay - Overlay content to write as CLAUDE.md, or undefined for guard-only deployment
+	 * @param overlay - Overlay content to write as AGENTS.md, or undefined for guard-only deployment
 	 * @param hooks - Agent identity, capability, worktree path, and optional quality gates
 	 */
 	async deployConfig(
@@ -129,9 +129,8 @@ export class PiRuntime implements AgentRuntime {
 		hooks: HooksDef,
 	): Promise<void> {
 		if (overlay) {
-			const claudeDir = join(worktreePath, ".claude");
-			await mkdir(claudeDir, { recursive: true });
-			await Bun.write(join(claudeDir, "CLAUDE.md"), overlay.content);
+			await mkdir(worktreePath, { recursive: true });
+			await Bun.write(join(worktreePath, this.instructionPath), overlay.content);
 		}
 
 		// Always deploy Pi guard extension.

--- a/src/runtimes/types.ts
+++ b/src/runtimes/types.ts
@@ -152,7 +152,7 @@ export interface AgentRuntime {
 	/** Stability level of this runtime adapter. */
 	readonly stability: "stable" | "beta" | "experimental";
 
-	/** Relative path to the instruction file within a worktree (e.g. ".claude/CLAUDE.md"). */
+	/** Relative path to the instruction file within a worktree (e.g. "AGENTS.md"). */
 	readonly instructionPath: string;
 
 	/** Build the shell command string to spawn an interactive agent in a tmux pane. */
@@ -168,7 +168,7 @@ export interface AgentRuntime {
 	 * Deploy per-agent instructions and guards to a worktree.
 	 * Claude Code writes .claude/CLAUDE.md + settings.local.json hooks.
 	 * Codex writes AGENTS.md (no hook deployment needed).
-	 * Pi writes .claude/CLAUDE.md + a guard extension in .pi/extensions/.
+	 * Pi writes AGENTS.md + a guard extension in .pi/extensions/.
 	 * When overlay is undefined, only hooks are deployed (no instruction file written).
 	 */
 	deployConfig(


### PR DESCRIPTION
## Summary
- switch the Pi runtime instruction path from `.claude/CLAUDE.md` to `AGENTS.md`
- write Pi overlays to `AGENTS.md` during runtime config deployment
- update Pi runtime docs and tests to match the new instruction path

## Testing
- bun run typecheck
- bun test src/runtimes/pi.test.ts
- bunx @biomejs/biome check src/runtimes/pi.ts src/runtimes/pi.test.ts src/runtimes/types.ts

Closes #121