### PR TITLE
fix: reduce doctor false positives

### DIFF
--- a/src/doctor/agents.test.ts
+++ b/src/doctor/agents.test.ts
@@ -124,13 +124,41 @@ describe("checkAgents", () => {
 		expect(parseCheck?.status).toBe("pass");
 	});
 
-	test("fails when agent has invalid model", async () => {
+	test("passes when agent uses a non-empty model string", async () => {
 		const manifest = {
 			version: "1.0",
 			agents: {
 				scout: {
 					file: "scout.md",
-					model: "invalid-model",
+					model: "gpt-5-4",
+					tools: ["Read"],
+					capabilities: ["explore"],
+					canSpawn: false,
+					constraints: [],
+				},
+			},
+			capabilityIndex: {
+				explore: ["scout"],
+			},
+		};
+
+		await mkdir(join(overstoryDir, "agent-defs"), { recursive: true });
+		await Bun.write(join(overstoryDir, "agent-manifest.json"), JSON.stringify(manifest, null, 2));
+		await Bun.write(join(overstoryDir, "agent-defs", "scout.md"), "# Scout");
+
+		const checks = await checkAgents(mockConfig, overstoryDir);
+
+		const parseCheck = checks.find((c) => c.name === "Manifest parsing");
+		expect(parseCheck?.status).toBe("pass");
+	});
+
+	test("fails when agent model is empty", async () => {
+		const manifest = {
+			version: "1.0",
+			agents: {
+				scout: {
+					file: "scout.md",
+					model: "",
 					tools: ["Read"],
 					capabilities: ["explore"],
 					canSpawn: false,
@@ -148,7 +176,9 @@ describe("checkAgents", () => {
 
 		const parseCheck = checks.find((c) => c.name === "Manifest parsing");
 		expect(parseCheck?.status).toBe("fail");
-		expect(parseCheck?.details?.some((d) => d.includes("model"))).toBe(true);
+		expect(parseCheck?.details?.some((d) => d.includes('"model" must be a non-empty string'))).toBe(
+			true,
+		);
 	});
 
 	test("fails when agent has zero capabilities", async () => {
@@ -378,7 +408,44 @@ sessionsCompleted: -5
 		expect(identityCheck?.details?.some((d) => d.includes("sessionsCompleted"))).toBe(true);
 	});
 
-	test("warns about stale identity files", async () => {
+	test("does not warn for runtime-named identities when the recorded role exists", async () => {
+		const manifest = {
+			version: "1.0",
+			agents: {
+				scout: {
+					file: "scout.md",
+					model: "haiku",
+					tools: ["Read"],
+					capabilities: ["explore"],
+					canSpawn: false,
+					constraints: [],
+				},
+			},
+			capabilityIndex: {
+				explore: ["scout"],
+			},
+		};
+
+		await mkdir(join(overstoryDir, "agent-defs"), { recursive: true });
+		await mkdir(join(overstoryDir, "agents", "scout-task-123"), { recursive: true });
+		await Bun.write(join(overstoryDir, "agent-manifest.json"), JSON.stringify(manifest, null, 2));
+		await Bun.write(join(overstoryDir, "agent-defs", "scout.md"), "# Scout");
+
+		const identity = `name: scout-task-123
+capability: scout
+created: "2024-01-01T00:00:00Z"
+sessionsCompleted: 5
+`;
+
+		await Bun.write(join(overstoryDir, "agents", "scout-task-123", "identity.yaml"), identity);
+
+		const checks = await checkAgents(mockConfig, overstoryDir);
+
+		const staleCheck = checks.find((c) => c.name === "Stale identities");
+		expect(staleCheck).toBeUndefined();
+	});
+
+	test("warns about stale identity files when the recorded role is missing", async () => {
 		const manifest = {
 			version: "1.0",
 			agents: {
@@ -413,7 +480,7 @@ sessionsCompleted: 5
 
 		const staleCheck = checks.find((c) => c.name === "Stale identities");
 		expect(staleCheck?.status).toBe("warn");
-		expect(staleCheck?.details?.some((d) => d.includes("old-agent"))).toBe(true);
+		expect(staleCheck?.details?.some((d) => d.includes("obsolete"))).toBe(true);
 	});
 
 	test("warns when identity name contains invalid characters", async () => {

--- a/src/doctor/agents.ts
+++ b/src/doctor/agents.ts
@@ -3,7 +3,6 @@ import { join } from "node:path";
 import type { AgentManifest } from "../types.ts";
 import type { DoctorCheck, DoctorCheckFn } from "./types.ts";
 
-const VALID_MODELS = new Set(["sonnet", "opus", "haiku"]);
 const VALID_NAME_REGEX = /^[a-zA-Z0-9_-]+$/;
 
 /**
@@ -64,8 +63,8 @@ async function loadAndValidateManifest(
 				errors.push(`Agent "${name}": "file" must be a non-empty string`);
 			}
 
-			if (typeof agentDef.model !== "string" || !VALID_MODELS.has(agentDef.model)) {
-				errors.push(`Agent "${name}": "model" must be one of: sonnet, opus, haiku`);
+			if (typeof agentDef.model !== "string" || agentDef.model.length === 0) {
+				errors.push(`Agent "${name}": "model" must be a non-empty string`);
 			}
 
 			if (!Array.isArray(agentDef.tools)) {
@@ -313,12 +312,6 @@ export const checkAgents: DoctorCheckFn = async (_config, overstoryDir): Promise
 
 			identityFileCount++;
 
-			// Check if agent still exists in manifest
-			if (!manifest.agents[agentName]) {
-				staleIdentities.push(agentName);
-				continue;
-			}
-
 			// Parse and validate identity
 			try {
 				const content = await Bun.file(identityPath).text();
@@ -344,6 +337,13 @@ export const checkAgents: DoctorCheckFn = async (_config, overstoryDir): Promise
 
 				if (typeof identity.sessionsCompleted !== "number" || identity.sessionsCompleted < 0) {
 					identityErrors.push(`${agentName}: "sessionsCompleted" must be a non-negative integer`);
+				}
+
+				// Identity directories are keyed by runtime agent names (for example
+				// lead-foo-1234), not by manifest role names. Validate the recorded
+				// role/capability against the manifest instead of the directory name.
+				if (identity.capability && !manifest.agents[identity.capability]) {
+					staleIdentities.push(`${agentName} (capability: ${identity.capability})`);
 				}
 
 				// Validate name is valid identifier
@@ -384,7 +384,7 @@ export const checkAgents: DoctorCheckFn = async (_config, overstoryDir): Promise
 				category: "agents",
 				status: "warn",
 				message: `Found ${staleIdentities.length} stale identity file(s)`,
-				details: staleIdentities.map((name) => `${name} (agent no longer in manifest)`),
+				details: staleIdentities.map((name) => `${name} (role not present in manifest)`),
 				fixable: true,
 			});
 		}

--- a/src/doctor/consistency.test.ts
+++ b/src/doctor/consistency.test.ts
@@ -375,6 +375,41 @@ describe("checkConsistency", () => {
 		expect(warnOrFail.length).toBe(0);
 	});
 
+	test("ignores completed sessions whose tmux, pid, and worktree are gone", async () => {
+		const dbPath = join(overstoryDir, "sessions.db");
+		const store = createSessionStore(dbPath);
+
+		store.upsert({
+			id: "session-1",
+			agentName: "completed-agent",
+			capability: "builder",
+			worktreePath: join(overstoryDir, "worktrees", "completed-agent"),
+			branchName: "overstory/completed-agent/test-123",
+			taskId: "test-123",
+			tmuxSession: "overstory-testproject-completed-agent",
+			state: "completed",
+			pid: 99999,
+			parentAgent: null,
+			depth: 0,
+			runId: null,
+			startedAt: new Date().toISOString(),
+			lastActivity: new Date().toISOString(),
+			escalationLevel: 0,
+			stalledSince: null,
+			transcriptPath: null,
+		});
+		store.close();
+
+		mockIsProcessAlive.mockReturnValue(false);
+		mockListSessions.mockResolvedValue([]);
+
+		const checks = await checkConsistency(config, overstoryDir, mockDeps);
+
+		expect(checks.find((c) => c.name === "dead-pids")?.status).toBe("pass");
+		expect(checks.find((c) => c.name === "missing-worktrees")?.status).toBe("pass");
+		expect(checks.find((c) => c.name === "missing-tmux")?.status).toBe("pass");
+	});
+
 	test("handles tmux not installed gracefully", async () => {
 		// Mock tmux listing to throw an error
 		mockListSessions.mockRejectedValue(new Error("tmux: command not found"));

--- a/src/doctor/consistency.ts
+++ b/src/doctor/consistency.ts
@@ -89,6 +89,10 @@ export async function checkConsistency(
 		return checks;
 	}
 
+	// Completed/zombie sessions are retained for history and metrics. Their tmux
+	// sessions, PIDs, and worktrees may legitimately be gone.
+	const liveSessions = storeSessions.filter((s) => s.state !== "completed" && s.state !== "zombie");
+
 	// Now perform cross-validation checks
 
 	// 4. Check for orphaned worktrees (worktree exists but no SessionStore entry)
@@ -155,7 +159,7 @@ export async function checkConsistency(
 	}
 
 	// 6. Check for dead processes in SessionStore
-	const deadSessions = storeSessions.filter((s) => s.pid !== null && !isProcessAliveFn(s.pid));
+	const deadSessions = liveSessions.filter((s) => s.pid !== null && !isProcessAliveFn(s.pid));
 
 	if (deadSessions.length > 0) {
 		checks.push({
@@ -177,7 +181,7 @@ export async function checkConsistency(
 
 	// 7. Check for SessionStore entries with missing worktrees
 	const existingWorktreePaths = new Set(worktrees.map((wt) => wt.path));
-	const missingWorktrees = storeSessions.filter((s) => {
+	const missingWorktrees = liveSessions.filter((s) => {
 		// Try to normalize the SessionStore path for comparison
 		try {
 			const normalizedPath = realpathSync(s.worktreePath);
@@ -208,7 +212,7 @@ export async function checkConsistency(
 
 	// 8. Check for SessionStore entries with missing tmux sessions
 	const existingTmuxNames = new Set(tmuxSessions.map((s) => s.name));
-	const missingTmux = storeSessions.filter((s) => !existingTmuxNames.has(s.tmuxSession));
+	const missingTmux = liveSessions.filter((s) => !existingTmuxNames.has(s.tmuxSession));
 
 	if (missingTmux.length > 0) {
 		checks.push({


### PR DESCRIPTION
## Summary
- accept any non-empty agent manifest model string in `doctor`, matching the runtime manifest loader
- validate identity files against the recorded role/capability instead of treating runtime agent names as manifest keys
- ignore completed/zombie sessions when checking live runtime resources in the consistency doctor checks

Closes #124.

## Verification
- `bun test src/doctor/agents.test.ts src/doctor/consistency.test.ts`
- `bun run typecheck`
