### PR TITLE
feat: normalize Windows paths in hooks-deployer scripts

### DIFF
--- a/src/agents/hooks-deployer.test.ts
+++ b/src/agents/hooks-deployer.test.ts
@@ -1,9 +1,9 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { AgentError } from "../errors.ts";
-import { cleanupTempDir } from "../test-helpers.ts";
+import { cleanupTempDir, posixShExecutable } from "../test-helpers.ts";
 import {
 	buildBashFileGuardScript,
 	buildBashPathBoundaryScript,
@@ -425,12 +425,13 @@ describe("deployHooks", () => {
 	});
 
 	test("write failure throws AgentError", async () => {
-		// Use a path that will fail to write (read-only parent)
-		const invalidPath = "/dev/null/impossible-path";
+		// Using a file as the worktree path makes mkdir(.claude) fail with ENOTDIR on
+		// every OS. A Unix-only trick like /dev/null/... succeeds on Windows as a normal path.
+		const notADirectory = join(tempDir, "not-a-directory");
+		await Bun.write(notADirectory, "");
 
 		try {
-			await deployHooks(invalidPath, "fail-agent");
-			// Should not reach here
+			await deployHooks(notADirectory, "fail-agent");
 			expect(true).toBe(false);
 		} catch (err) {
 			expect(err).toBeInstanceOf(AgentError);
@@ -2404,6 +2405,12 @@ describe("PATH prefix in deployed hooks", () => {
 });
 
 describe("buildTrackerCloseGuardScript", () => {
+	let sh: string;
+
+	beforeAll(() => {
+		sh = posixShExecutable();
+	});
+
 	test("returns a string containing key patterns", () => {
 		const script = buildTrackerCloseGuardScript();
 		expect(typeof script).toBe("string");
@@ -2427,7 +2434,7 @@ describe("buildTrackerCloseGuardScript", () => {
 	test("blocks sd close with wrong ID", async () => {
 		const script = buildTrackerCloseGuardScript();
 		const input = JSON.stringify({ command: "sd close other-task" });
-		const proc = Bun.spawn(["sh", "-c", script], {
+		const proc = Bun.spawn([sh, "-c", script], {
 			stdin: new TextEncoder().encode(input),
 			stdout: "pipe",
 			stderr: "pipe",
@@ -2444,7 +2451,7 @@ describe("buildTrackerCloseGuardScript", () => {
 	test("allows sd close with matching ID", async () => {
 		const script = buildTrackerCloseGuardScript();
 		const input = JSON.stringify({ command: "sd close my-task" });
-		const proc = Bun.spawn(["sh", "-c", script], {
+		const proc = Bun.spawn([sh, "-c", script], {
 			stdin: new TextEncoder().encode(input),
 			stdout: "pipe",
 			stderr: "pipe",
@@ -2458,7 +2465,7 @@ describe("buildTrackerCloseGuardScript", () => {
 	test("blocks bd close with wrong ID", async () => {
 		const script = buildTrackerCloseGuardScript();
 		const input = JSON.stringify({ command: "bd close other-task" });
-		const proc = Bun.spawn(["sh", "-c", script], {
+		const proc = Bun.spawn([sh, "-c", script], {
 			stdin: new TextEncoder().encode(input),
 			stdout: "pipe",
 			stderr: "pipe",
@@ -2474,7 +2481,7 @@ describe("buildTrackerCloseGuardScript", () => {
 	test("blocks sd update --status with wrong ID", async () => {
 		const script = buildTrackerCloseGuardScript();
 		const input = JSON.stringify({ command: "sd update other-task --status in_progress" });
-		const proc = Bun.spawn(["sh", "-c", script], {
+		const proc = Bun.spawn([sh, "-c", script], {
 			stdin: new TextEncoder().encode(input),
 			stdout: "pipe",
 			stderr: "pipe",
@@ -2490,7 +2497,7 @@ describe("buildTrackerCloseGuardScript", () => {
 	test("exits early when OVERSTORY_TASK_ID is empty (coordinator/monitor)", async () => {
 		const script = buildTrackerCloseGuardScript();
 		const input = JSON.stringify({ command: "sd close coordinator-task" });
-		const proc = Bun.spawn(["sh", "-c", script], {
+		const proc = Bun.spawn([sh, "-c", script], {
 			stdin: new TextEncoder().encode(input),
 			stdout: "pipe",
 			stderr: "pipe",
@@ -2583,6 +2590,12 @@ describe("deployHooks tracker close guard integration", () => {
 });
 
 describe("escapeForSingleQuotedShell", () => {
+	let sh: string;
+
+	beforeAll(() => {
+		sh = posixShExecutable();
+	});
+
 	test("no single quotes: string passes through unchanged", () => {
 		expect(escapeForSingleQuotedShell("hello world")).toBe("hello world");
 	});
@@ -2605,7 +2618,7 @@ describe("escapeForSingleQuotedShell", () => {
 		expect(taskGuard).toBeDefined();
 		const cmd = taskGuard?.hooks[0]?.command ?? "";
 		const echoCmd = cmd.replace('[ -z "$OVERSTORY_AGENT_NAME" ] && exit 0; ', "");
-		const proc = Bun.spawn(["sh", "-c", echoCmd], {
+		const proc = Bun.spawn([sh, "-c", echoCmd], {
 			stdout: "pipe",
 			stderr: "pipe",
 			env: { ...process.env, OVERSTORY_AGENT_NAME: "test-agent" },

--- a/src/agents/hooks-deployer.ts
+++ b/src/agents/hooks-deployer.ts
@@ -115,6 +115,11 @@ export function buildPathBoundaryGuardScript(filePathField: string): string {
 		`FILE_PATH=$(echo "$INPUT" | sed -n 's/.*"${filePathField}": *"\\([^"]*\\)".*/\\1/p');`,
 		// No path extracted — fail open (tool may be called differently)
 		'[ -z "$FILE_PATH" ] && exit 0;',
+		// Normalize Windows paths to POSIX format when running under Git Bash / MSYS2
+		'if command -v cygpath >/dev/null 2>&1; then',
+		'  OVERSTORY_WORKTREE_PATH=$(cygpath -u "$OVERSTORY_WORKTREE_PATH");',
+		'  FILE_PATH=$(cygpath -u "$FILE_PATH");',
+		'fi;',
 		// Resolve relative paths against cwd
 		'case "$FILE_PATH" in /*) ;; *) FILE_PATH="$(pwd)/$FILE_PATH" ;; esac;',
 		// Allow if path is inside the worktree (exact match or subpath)
@@ -403,6 +408,10 @@ export function buildBashPathBoundaryScript(): string {
 		"PATHS=$(echo \"$CMD\" | tr ' \\t' '\\n\\n' | grep '^/' | sed 's/[\";>]*$//');",
 		// If no absolute paths found, allow (relative paths resolve from worktree cwd)
 		'[ -z "$PATHS" ] && exit 0;',
+		// Normalize Windows paths to POSIX format when running under Git Bash / MSYS2
+		'if command -v cygpath >/dev/null 2>&1; then',
+		'  OVERSTORY_WORKTREE_PATH=$(cygpath -u "$OVERSTORY_WORKTREE_PATH");',
+		'fi;',
 		// Check each absolute path against the worktree boundary
 		'echo "$PATHS" | while IFS= read -r P; do',
 		'  case "$P" in',

--- a/src/test-helpers.test.ts
+++ b/src/test-helpers.test.ts
@@ -1,8 +1,14 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { cleanupTempDir, commitFile, createTempGitRepo } from "./test-helpers.ts";
+import {
+	cleanupTempDir,
+	commitFile,
+	createTempGitRepo,
+	posixShExeNextToGitExe,
+} from "./test-helpers.ts";
 
 describe("createTempGitRepo", () => {
 	let repoDir: string | undefined;
@@ -121,4 +127,34 @@ describe("cleanupTempDir", () => {
 		await cleanupTempDir("/tmp/overstory-nonexistent-test-dir-12345");
 		// No error thrown = pass
 	});
+});
+
+describe("POSIX shell for hook script tests", () => {
+	test.skipIf(process.platform !== "win32")(
+		"Git for Windows: sh.exe is ..\\bin\\sh.exe or ..\\usr\\bin\\sh.exe relative to git.exe",
+		() => {
+			const r = spawnSync("where.exe", ["git"], { encoding: "utf8", windowsHide: true });
+			expect(r.status).toBe(0);
+			const gitExe = r.stdout
+				?.split(/\r?\n/)
+				.map((s) => s.trim())
+				.find(Boolean);
+			expect(gitExe).toBeDefined();
+			if (!gitExe) throw new Error("expected where.exe git to print a git.exe path");
+			expect(existsSync(gitExe)).toBe(true);
+
+			let found = false;
+			for (const line of r.stdout?.split(/\r?\n/) ?? []) {
+				const g = line.trim();
+				if (!g) continue;
+				const sh = posixShExeNextToGitExe(g);
+				if (sh) {
+					expect(sh.toLowerCase()).toMatch(/\\(bin|usr\\bin)\\sh\.exe$/i);
+					found = true;
+					break;
+				}
+			}
+			expect(found).toBe(true);
+		},
+	);
 });

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -1,6 +1,8 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 /**
  * Git environment variables for test repos.
@@ -13,6 +15,68 @@ const GIT_TEST_ENV = {
 	GIT_COMMITTER_NAME: "Overstory Test",
 	GIT_COMMITTER_EMAIL: "test@overstory.dev",
 };
+
+/** Env var: absolute path to `sh.exe` if Git’s default relative layout does not apply. */
+export const OVERSTORY_TEST_POSIX_SH = "OVERSTORY_TEST_POSIX_SH";
+
+let cachedPosixSh: string | undefined;
+
+/** First existing `sh.exe` next to a Git for Windows `git.exe`, or `undefined`.
+ * Prefers `Git\bin\sh.exe` (PATH for `sed`, `grep`, etc.) then `Git\usr\bin\sh.exe`. */
+export function posixShExeNextToGitExe(gitExe: string): string | undefined {
+	const root = dirname(gitExe);
+	const candidates = [
+		join(root, "..", "bin", "sh.exe"),
+		join(root, "..", "usr", "bin", "sh.exe"),
+	];
+	for (const p of candidates) {
+		if (existsSync(p)) return p;
+	}
+	return undefined;
+}
+
+function resolvePosixShExecutable(): string {
+	const override = process.env[OVERSTORY_TEST_POSIX_SH]?.trim();
+	if (override) {
+		if (existsSync(override)) return override;
+		throw new Error(
+			`${OVERSTORY_TEST_POSIX_SH} is set to "${override}" but that path does not exist.`,
+		);
+	}
+	if (process.platform !== "win32") {
+		return "sh";
+	}
+	// find where the git for windows executable is, we will use this to find the sh.exe next to it
+	const r = spawnSync("where.exe", ["git"], { encoding: "utf8", windowsHide: true });
+	if (r.status !== 0 || !r.stdout?.trim()) {
+		throw new Error(
+			"`where.exe git` failed; install Git for Windows and ensure `git` is on PATH, or set " +
+				`${OVERSTORY_TEST_POSIX_SH} to the full path of sh.exe.`,
+		);
+	}
+	for (const line of r.stdout.split(/\r?\n/)) {
+		const gitExe = line.trim();
+		if (!gitExe) continue;
+		const candidate = posixShExeNextToGitExe(gitExe);
+		if (candidate) return candidate;
+	}
+	throw new Error(
+		`Could not find bin\\sh.exe or usr\\bin\\sh.exe relative to Git for Windows. Set ${OVERSTORY_TEST_POSIX_SH}.`,
+	);
+}
+
+/**
+ * POSIX shell executable for tests: `sh` on Unix, or Git for Windows `bin\sh.exe` (preferred) / `usr\bin\sh.exe`.
+ *
+ * On Windows: `where.exe git`, then existing `..\bin\sh.exe` or `..\usr\bin\sh.exe` from each `git.exe`.
+ * Override with {@link OVERSTORY_TEST_POSIX_SH}.
+ */
+export function posixShExecutable(): string {
+	if (!cachedPosixSh) {
+		cachedPosixSh = resolvePosixShExecutable();
+	}
+	return cachedPosixSh;
+}
 
 /** Cached template repo path. Created lazily on first call. */
 let _templateDir: string | null = null;

--- a/src/worktree/process.test.ts
+++ b/src/worktree/process.test.ts
@@ -1,12 +1,19 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnHeadlessAgent } from "./process.ts";
+import { posixShExecutable } from "../test-helpers.ts";
 
 describe("spawnHeadlessAgent", () => {
+	let sh: string;
+
+	beforeAll(() => {
+		sh = posixShExecutable();
+	});
+
 	it("spawns a command and returns a valid PID", async () => {
-		const proc = await spawnHeadlessAgent(["echo", "hello"], {
+		const proc = await spawnHeadlessAgent([sh, "-c", "echo hello"], {
 			cwd: process.cwd(),
 			env: { ...(process.env as Record<string, string>) },
 		});
@@ -35,7 +42,7 @@ describe("spawnHeadlessAgent", () => {
 
 		it("redirects stdout to file when stdoutFile is provided", async () => {
 			const stdoutFile = join(tmpDir, "stdout.log");
-			const proc = await spawnHeadlessAgent(["echo", "hello from file"], {
+			const proc = await spawnHeadlessAgent([sh, "-c", "echo hello from file"], {
 				cwd: process.cwd(),
 				env: { ...(process.env as Record<string, string>) },
 				stdoutFile,
@@ -48,7 +55,7 @@ describe("spawnHeadlessAgent", () => {
 			expect(proc.stdin).toBeDefined();
 
 			// Wait for process to finish, then check file content
-			const exitProc = Bun.spawn(["sh", "-c", "true"], { stdout: "pipe" });
+			const exitProc = Bun.spawn([sh, "-c", "true"], { stdout: "pipe" });
 			await exitProc.exited;
 			// Give echo a moment to flush
 			await Bun.sleep(100);
@@ -60,7 +67,7 @@ describe("spawnHeadlessAgent", () => {
 		it("redirects stderr to file when stderrFile is provided", async () => {
 			const stderrFile = join(tmpDir, "stderr.log");
 			// Write to stderr via sh -c
-			const proc = await spawnHeadlessAgent(["sh", "-c", "echo error output >&2"], {
+			const proc = await spawnHeadlessAgent([sh, "-c", "echo error output >&2"], {
 				cwd: process.cwd(),
 				env: { ...(process.env as Record<string, string>) },
 				stderrFile,
@@ -85,7 +92,7 @@ describe("spawnHeadlessAgent", () => {
 		});
 
 		it("stdout remains a ReadableStream when no stdoutFile provided (default mode)", async () => {
-			const proc = await spawnHeadlessAgent(["echo", "piped"], {
+			const proc = await spawnHeadlessAgent([sh, "-c", "echo piped"], {
 				cwd: process.cwd(),
 				env: { ...(process.env as Record<string, string>) },
 			});


### PR DESCRIPTION
Fixed #141 

## Summary

Added support for normalizing Windows paths to POSIX format in the following functions when running under Git Bash or MSYS2

- buildPathBoundaryGuardScript
- buildBashPathBoundaryScript 

## Changes

- git hooks

## Test plan

- [ ] `biome check .` passes
- [ ] `tsc --noEmit` passes
- [x] `bun test` passes
- [ ] Manual verification (if applicable)

I tested in windows and WSL2 (Ubuntu):

```sh
bun test src/agents/hooks-deployer.test.ts

...
196 pass
 0 fail
 621 expect() calls
Ran 196 tests across 1 file. [2.12s]
```
and 
```sh
bun test src/test-helpers.test.ts
bun test v1.3.12 (700fc117)

src\test-helpers.test.ts:
✓ createTempGitRepo > creates a directory with an initialized git repo [390.00ms]
✓ createTempGitRepo > repo has at least one commit (HEAD exists) [235.00ms]
✓ createTempGitRepo > repo is on a branch (not detached HEAD) [250.00ms]
✓ commitFile > creates file and commits it [375.00ms]
✓ commitFile > creates nested directories as needed [359.00ms]
✓ commitFile > uses custom commit message when provided [391.00ms]
✓ cleanupTempDir > removes directory and all contents [343.00ms]
✓ cleanupTempDir > does not throw when directory does not exist
✓ POSIX shell for hook script tests > Git for Windows: sh.exe is ..\bin\sh.exe or ..\usr\bin\sh.exe relative to git.exe [94.00ms]

 9 pass
 0 fail
 15 expect() calls
Ran 9 tests across 1 file. [2.50s]
```
and
```sh
bun test .\src\worktree\process.test.ts
bun test v1.3.12 (700fc117)

src\worktree\process.test.ts:
✓ spawnHeadlessAgent > spawns a command and returns a valid PID
✓ spawnHeadlessAgent > throws AgentError when argv is empty
✓ spawnHeadlessAgent > file redirect mode > redirects stdout to file when stdoutFile is provided [203.00ms]
✓ spawnHeadlessAgent > file redirect mode > redirects stderr to file when stderrFile is provided [157.00ms]
✓ spawnHeadlessAgent > file redirect mode > stdout remains a ReadableStream when no stdoutFile provided (default mode) [31.00ms]

 5 pass
 0 fail
 16 expect() calls
Ran 5 tests across 1 file. [546.00ms]
```