### PR TITLE
Ensure text files use lf, not crlf on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,5 @@
 .canopy/schemas.jsonl merge=union
 
 .sapling/session.jsonl merge=union
+
+* text=auto eol=lf

--- a/biome.json
+++ b/biome.json
@@ -32,6 +32,7 @@
 	"formatter": {
 		"enabled": true,
 		"indentStyle": "tab",
-		"lineWidth": 100
+		"lineWidth": 100,
+		"lineEnding": "lf"
 	}
 }


### PR DESCRIPTION
## Summary

#145 - Fixes line ending issues when cloning repos on Windows, especially when run `bun run lint`

## Changes

- add `* text=auto eol=lf` to `.gitattributes` to ensure all text files use lf as line endings
- add `"lineEnding": "lf"` to `biome.json` to make it explicit even though `lf` is default

## Test plan

- [ ] `biome check .` passes
- [ ] `tsc --noEmit` passes
- [ ] `bun test` passes
- [ ] Manual verification (if applicable)


## Remarks 



I noticed on main, these lints are broken unrelated to my PR.



```

$ biome check .
src\watchdog\daemon.test.ts:2313:15 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  i The computed expression can be simplified without the use of a string literal.

    2311 │                                      logPath: "/fake/one/stdout.log",
    2312 │                                      stop: () => {
  > 2313 │                                              stopped["tailer1"] = true;
         │                                                      ^^^^^^^^^
    2314 │                                      },
    2315 │                              },

  i Unsafe fix: Use a literal key instead.

    2311 2311 │                                         logPath: "/fake/one/stdout.log",
    2312 2312 │                                         stop: () => {
    2313      │ - → → → → → → stopped["tailer1"]·=·true;
         2313 │ + → → → → → → stopped.tailer1·=·true;
    2314 2314 │                                         },
    2315 2315 │                                 },


src\watchdog\daemon.test.ts:2323:15 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  i The computed expression can be simplified without the use of a string literal.

    2321 │                                      logPath: "/fake/two/stdout.log",
    2322 │                                      stop: () => {
  > 2323 │                                              stopped["tailer2"] = true;
         │                                                      ^^^^^^^^^
    2324 │                                      },
    2325 │                              },

  i Unsafe fix: Use a literal key instead.

    2321 2321 │                                         logPath: "/fake/two/stdout.log",
    2322 2322 │                                         stop: () => {
    2323      │ - → → → → → → stopped["tailer2"]·=·true;
         2323 │ + → → → → → → stopped.tailer2·=·true;
    2324 2324 │                                         },
    2325 2325 │                                 },


src\watchdog\daemon.test.ts:2353:18 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  i The computed expression can be simplified without the use of a string literal.

    2351 │              daemon.stop();
    2352 │
  > 2353 │              expect(stopped["tailer1"]).toBe(true);
         │                             ^^^^^^^^^
    2354 │              expect(stopped["tailer2"]).toBe(true);
    2355 │              expect(registry.size).toBe(0);

  i Unsafe fix: Use a literal key instead.

    2351 2351 │                 daemon.stop();
    2352 2352 │
    2353      │ - → → expect(stopped["tailer1"]).toBe(true);
         2353 │ + → → expect(stopped.tailer1).toBe(true);
    2354 2354 │                 expect(stopped["tailer2"]).toBe(true);
    2355 2355 │                 expect(registry.size).toBe(0);


src\watchdog\daemon.test.ts:2354:18 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  i The computed expression can be simplified without the use of a string literal.

    2353 │              expect(stopped["tailer1"]).toBe(true);
  > 2354 │              expect(stopped["tailer2"]).toBe(true);
         │                             ^^^^^^^^^
    2355 │              expect(registry.size).toBe(0);
    2356 │      });

  i Unsafe fix: Use a literal key instead.

    2352 2352 │
    2353 2353 │                 expect(stopped["tailer1"]).toBe(true);
    2354      │ - → → expect(stopped["tailer2"]).toBe(true);
         2354 │ + → → expect(stopped.tailer2).toBe(true);
    2355 2355 │                 expect(registry.size).toBe(0);
    2356 2356 │         });
    
    ```