### PR TITLE
fix(tmux): treat "no server running" as success in killSession

### DIFF
--- a/src/worktree/tmux.test.ts
+++ b/src/worktree/tmux.test.ts
@@ -790,6 +790,24 @@ describe("killSession", () => {
 		await killSession("overstory-auth");
 	});
 
+	test("succeeds silently when tmux server is not running", async () => {
+		spawnSpy.mockImplementation((...args: unknown[]) => {
+			const cmd = args[0] as string[];
+			if (cmd[0] === "tmux" && cmd[3] === "display-message") {
+				// getPanePid → no server running
+				return mockSpawnResult("", "no server running on /tmp/tmux-501/overstory", 1);
+			}
+			if (cmd[0] === "tmux" && cmd[3] === "kill-session") {
+				// kill-session also reports no server
+				return mockSpawnResult("", "no server running on /tmp/tmux-501/overstory", 1);
+			}
+			return mockSpawnResult("", "", 0);
+		});
+
+		// Should not throw — no server means the session is trivially gone
+		await killSession("overstory-auth");
+	});
+
 	test("throws AgentError on unexpected tmux kill-session failure", async () => {
 		spawnSpy.mockImplementation((...args: unknown[]) => {
 			const cmd = args[0] as string[];

--- a/src/worktree/tmux.ts
+++ b/src/worktree/tmux.ts
@@ -409,8 +409,13 @@ export async function killSession(name: string): Promise<void> {
 	const { exitCode, stderr } = await runCommand(tmuxCmd("kill-session", "-t", name));
 
 	if (exitCode !== 0) {
-		// If the session is already gone (e.g., died during process cleanup), that's fine
-		if (stderr.includes("session not found") || stderr.includes("can't find session")) {
+		// If the session is already gone (e.g., died during process cleanup,
+		// or the whole tmux server exited), that's fine — the goal state is reached.
+		if (
+			stderr.includes("session not found") ||
+			stderr.includes("can't find session") ||
+			stderr.includes("no server running")
+		) {
 			return;
 		}
 		throw new AgentError(`Failed to kill tmux session "${name}": ${stderr.trim()}`, {


### PR DESCRIPTION
## Summary

`killSession` in `src/worktree/tmux.ts` whitelists only `"session not found"` and `"can't find session"` as benign stderr signals from `tmux kill-session`. When the tmux server itself has exited (reboot, `tmux kill-server`, the last pane closed), tmux emits a third string — `"no server running on <socket>"` — which isn't whitelisted, so `killSession` throws `AgentError`.

In practice this surfaces as a blocking error on `ov coordinator start`:

```
Error [AGENT_ERROR]: Failed to kill tmux session "overstory-<project>-coordinator": no server running on /private/tmp/tmux-501/overstory
```

Reproduction: leave a coordinator record in `sessions.db`, kill the tmux server (or reboot), then run `ov coordinator start`. The zombie-cleanup path (session record alive, process dead) calls `killSession` to reclaim the slot and aborts instead of silently succeeding.

## Fix

Add `"no server running"` to the `killSession` stderr whitelist. Semantically it's strictly stronger than `"session not found"` for this operation — if the server is gone, the session is trivially gone too. This matches what `listSessions` already does in the same file (`src/worktree/tmux.ts:210`).

## Diff

- `src/worktree/tmux.ts` — extend the benign-stderr check in `killSession`.
- `src/worktree/tmux.test.ts` — regression test covering both `getPanePid` and `kill-session` reporting `"no server running"`.

## Test plan

- [x] `bun test src/worktree/tmux.test.ts` → 86 pass / 0 fail
- [x] `bun x biome check src/worktree/tmux.ts src/worktree/tmux.test.ts` → clean
- [x] `bun x tsc --noEmit` → clean
- [x] Manually reproduced the original error, applied fix, confirmed `ov coordinator start` proceeds past the kill step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)